### PR TITLE
Upload videos in series rather than parallel

### DIFF
--- a/upload_videos_to_redcap_project.js
+++ b/upload_videos_to_redcap_project.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const fs = require('fs')
-const { exec } = require('child_process')
+const { execSync } = require('child_process')
 
 /**
  * This tool fetches the results of the latest cloud run
@@ -125,7 +125,7 @@ class UploadVideosToREDCapProject {
                                     }
 
                                     //Run the import of video to REDCAP VUMC
-                                    exec(`sh import_video.sh "${file_path}" "${filename}" ${folder_id}`,
+                                    execSync(`sh import_video.sh "${file_path}" "${filename}" ${folder_id}`,
                                         (error, stdout, stderr) => {
                                             if (error) {
                                                 console.error(`Error executing script: ${error.message}`)


### PR DESCRIPTION
@aldefouw, I suspect our video uploads didn't process in one go because they were all executed in parallel (simultaneously).  This PR makes them upload in series.  What are your thoughts?