### PR TITLE
Removed extraneous project status change language

### DIFF
--- a/Feature Tests/A/Bulk Record Delete_32/A.3.32.0100. - Bulk Record Delete.feature
+++ b/Feature Tests/A/Bulk Record Delete_32/A.3.32.0100. - Bulk Record Delete.feature
@@ -15,7 +15,7 @@ Feature: A.3.32.0100. The system shall allow REDCap administrators to enable or 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Other Functionality"

--- a/Feature Tests/A/Field Validation_8/A.4.8.0100. - Enable field validation.feature
+++ b/Feature Tests/A/Field Validation_8/A.4.8.0100. - Enable field validation.feature
@@ -12,7 +12,7 @@ Feature: Control Center: The system shall support the enabling/disabling of fiel
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/A/File Repository_26/A.3.26.0100. - Public File Share.feature
+++ b/Feature Tests/A/File Repository_26/A.3.26.0100. - Public File Share.feature
@@ -15,7 +15,7 @@ Feature: Control Center: The system shall provide the ability to enable/disable 
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #ACTION Upload to top tier file repo (all users will see file) - using the Select files to upload button

--- a/Feature Tests/A/Project Setup_4/A.6.4.0200. - Move to Production.feature
+++ b/Feature Tests/A/Project Setup_4/A.6.4.0200. - Move to Production.feature
@@ -31,7 +31,7 @@ Feature: A.6.4.0200. Manage project creation, deletion, and settings
 
         When I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "Yes, Request Admin to Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "Yes, Request Admin to Move to Production Status" in the dialog box
         Then I should see "Request pending"
         And I click on the link labeled "Logging"
         Then I should see a table header and rows containing the following values in the logging table:
@@ -93,7 +93,7 @@ Feature: A.6.4.0200. Manage project creation, deletion, and settings
 
         Given I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
         Given I click on the link labeled "Logging"
         Then I should see a table header and rows containing the following values in the logging table:

--- a/Feature Tests/A/Project Setup_4/A.6.4.0300. - REDUNDANT Edit Survey Responses.feature
+++ b/Feature Tests/A/Project Setup_4/A.6.4.0300. - REDUNDANT Edit Survey Responses.feature
@@ -14,7 +14,7 @@ Feature: A.6.4.0300. Manage project creation, deletion, and settings
         # When I click on the link labeled "Project Setup"
         # And I click on the button labeled "Move project to production"
         # And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        # And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        # And I click on the button labeled "YES, Move to Production Status" in the dialog box
         # Then I should see Project status: "Production"
 
         # And I click on the link labeled "User Rights"

--- a/Feature Tests/A/Project Setup_4/A.6.4.0400. - Draft Mode.feature
+++ b/Feature Tests/A/Project Setup_4/A.6.4.0400. - Draft Mode.feature
@@ -32,7 +32,7 @@ Feature: A.6.4.0400. Manage project creation, deletion, and settings. Control Ce
     Given I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     And I click on the link labeled "Logging"
@@ -152,7 +152,7 @@ Feature: A.6.4.0400. Manage project creation, deletion, and settings. Control Ce
     Given I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     When I click on the link labeled "Control Center"
@@ -237,7 +237,7 @@ Feature: A.6.4.0400. Manage project creation, deletion, and settings. Control Ce
     Given I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     When I click on the link labeled "Control Center"

--- a/Feature Tests/A/Project Setup_4/A.6.4.0500. - Repeatable Instruments.feature
+++ b/Feature Tests/A/Project Setup_4/A.6.4.0500. - Repeatable Instruments.feature
@@ -18,7 +18,7 @@ Feature: A.6.4.0500. Control Center: The system shall support the option to limi
             Given I click on the link labeled "Project Setup"
             And I click on the button labeled "Move project to production"
             And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-            And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+            And I click on the button labeled "YES, Move to Production Status" in the dialog box
             Then I should see Project status: "Production"
 
             When I click on the link labeled "Control Center"

--- a/Feature Tests/A/Project Setup_4/A.6.4.0600. - Events and Arms in Production.feature
+++ b/Feature Tests/A/Project Setup_4/A.6.4.0600. - Events and Arms in Production.feature
@@ -172,7 +172,7 @@ Feature: A.6.4.0600 Manage project creation, deletion, and settings. Control Cen
         And I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Control Center"

--- a/Feature Tests/A/Project Status_11/A.6.11.0100. - Administrative Controls in Control Center.feature
+++ b/Feature Tests/A/Project Status_11/A.6.11.0100. - Administrative Controls in Control Center.feature
@@ -74,7 +74,7 @@ Feature: A.6.11.0100. Control Center: The system shall support limiting the abil
     And I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
 
     ##VERIFY
     Then I should see Project status: "Production"

--- a/Feature Tests/A/e-Consent framework_24/A.3.24.1000. - eConsent IP address.feature
+++ b/Feature Tests/A/e-Consent framework_24/A.3.24.1000. - eConsent IP address.feature
@@ -13,7 +13,7 @@ Feature: Control Center: The system shall support capturing the IP address of su
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #Verify IP status

--- a/Feature Tests/A/e-Consent framework_24/A.3.24.3000. - eConsent PL edit.feature
+++ b/Feature Tests/A/e-Consent framework_24/A.3.24.3000. - eConsent PL edit.feature
@@ -13,7 +13,7 @@ Feature: A.3.24.3000. The system shall support the ability for administrators to
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: #FUNCTIONAL_REQUIREMENT
@@ -61,7 +61,7 @@ Feature: A.3.24.3000. The system shall support the ability for administrators to
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: #FUNCTIONAL_REQUIREMENT Do NOT capture IP Address
@@ -155,7 +155,7 @@ Feature: A.3.24.3000. The system shall support the ability for administrators to
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: #FUNCTIONAL_REQUIREMENT Custom Message on e-Consent Framework

--- a/Feature Tests/B/Assign User Rights_6/B.2.6.0100. - Basic Privileges.feature
+++ b/Feature Tests/B/Assign User Rights_6/B.2.6.0100. - Basic Privileges.feature
@@ -15,7 +15,7 @@ Feature: Project Level: The system shall allow the ability to add, edit or delet
         And I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I see Project status: "Production"
 
         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Assign User Rights_6/B.2.6.0200. - Data Entry Form Access.feature
+++ b/Feature Tests/B/Assign User Rights_6/B.2.6.0200. - Data Entry Form Access.feature
@@ -12,7 +12,7 @@ Feature: Project Level:  The system shall allow data entry form user access to b
     And I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     When I click on the link labeled "User Rights"

--- a/Feature Tests/B/Assign User Rights_6/B.2.6.0300. - Data Export Rights.feature
+++ b/Feature Tests/B/Assign User Rights_6/B.2.6.0300. - Data Export Rights.feature
@@ -12,7 +12,7 @@ Feature: Project Level:  The system shall allow instrument level data export rig
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##USER_RIGHTS

--- a/Feature Tests/B/Bulk Record Delete_32/B.3.32.0200. - Bulk Record Delete.feature
+++ b/Feature Tests/B/Bulk Record Delete_32/B.3.32.0200. - Bulk Record Delete.feature
@@ -14,7 +14,7 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
     Scenario:  #SET UP_USER_RIGHTS

--- a/Feature Tests/B/Data Import_16/B.3.16.0100. - Import Templates - Columns & Rows.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0100. - Import Templates - Columns & Rows.feature
@@ -10,7 +10,7 @@ Feature: User Interface: The system shall support the ability to download two ve
     #SETUP_PRODUCTION
     When I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Data Import_16/B.3.16.0205. - Create & Modify Records.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0205. - Create & Modify Records.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall allow data to be uploaded in real-time
         #SETUP_PRODUCTION
         When I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #VERIFY_RSD

--- a/Feature Tests/B/Data Import_16/B.3.16.0400. - Field Validation.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0400. - Field Validation.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall import only valid formats for text fie
         #SETUP_PRODUCTION
         When I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I see Project status: "Production"
 
         #VERIFY_RSD: no records exist

--- a/Feature Tests/B/Data Import_16/B.3.16.0500. - Choices for Radios, Dropdowns, Checkboxes.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0500. - Choices for Radios, Dropdowns, Checkboxes.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall import only valid choice codes for rad
         #SETUP_PRODUCTION
         When I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I see Project status: "Production"
 
         When I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.0600. - Survey Data Import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0600. - Survey Data Import.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall ignore survey identifier and timestamp
         #SETUP_PRODUCTION
         When I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.0700. - Longitudinal Data Import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0700. - Longitudinal Data Import.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall require the event name in the csv file
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Data Import_16/B.3.16.0800. - Repeat Instrument Import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0800. - Repeat Instrument Import.feature
@@ -21,7 +21,7 @@ Feature: User Interface: The system shall require the repeating instrument and i
     #SETUP_PRODUCTION
     When I click on the button labeled "Move project to production"
     And I click on the radio labeled "Delete ALL data in the project" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     #Manual: Will have to accept confirmation window "And I click on the button labeled "Ok" in the pop-up box"
     Then I see Project status: "Production"
 

--- a/Feature Tests/B/Data Import_16/B.3.16.0900. - Import Restrictions.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0900. - Import Restrictions.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall not allow data to be changed on locked
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##ACTION: Import data

--- a/Feature Tests/B/Data Import_16/B.3.16.1000. - Access Restrictions.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1000. - Access Restrictions.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall not allow a new record to be imported 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I see Project status: "Production"
 
         #USER_RIGHTS

--- a/Feature Tests/B/Data Import_16/B.3.16.1100. - Change with edit access.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1100. - Change with edit access.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall allow data to be changed only by a use
         #SETUP_PRODUCTION
         When I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##ACTION: Import data

--- a/Feature Tests/B/Data Import_16/B.3.16.1200. - Overwrite Existing Data.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1200. - Overwrite Existing Data.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall provide the option to allow blank valu
     #SETUP_PRODUCTION
     When I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##Verify Data present

--- a/Feature Tests/B/Data Import_16/B.3.16.1300. - Data Import - DAGs.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1300. - Data Import - DAGs.feature
@@ -30,7 +30,7 @@ Feature: B.3.16.1300. User Interface: The system shall provide the ability to as
         Given I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         Given I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.1400. - Background data import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1400. - Background data import.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall allow data to be uploaded as backgroun
         Given I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         Given I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.1600. - Background erorr report.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1600. - Background erorr report.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall report background process data import 
         Given I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         Given I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.1700. - export error report.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1700. - export error report.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall report background process data import 
         Given I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         Given I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.1800. - Comparison table.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1800. - Comparison table.feature
@@ -12,7 +12,7 @@ Feature: User Interface:The system shall provide the ability to display real-tim
         Given I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         Given I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.1900. - Rename duplicate record.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1900. - Rename duplicate record.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall provide the ability to create a new re
         Given I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         Given I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Data Import_16/B.3.16.2100. - Stop background import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.2100. - Stop background import.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall provide the ability for the user impor
         Given I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         Given I click on the link labeled "Data Import Tool"

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0100. - Create Record.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0100. - Create Record.feature
@@ -11,7 +11,7 @@ Feature: Creating a Record and Entering Data: The system shall support the abili
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I see Project status: "Production"
 
         ##SETUP_USER_RIGHTS

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0200. - Field Type Data Entry.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0200. - Field Type Data Entry.feature
@@ -24,7 +24,7 @@ Feature: Creating a Record and Entering Data: The system shall support data entr
     And I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #SETUP

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0300. - Radio button behavior.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0300. - Radio button behavior.feature
@@ -22,7 +22,7 @@ Feature: Creating a Record and Entering Data: The system shall support the abili
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##ACTION

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0400. - Datetime Fields.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0400. - Datetime Fields.feature
@@ -22,7 +22,7 @@ Feature: Creating a Record and Entering Data: The system shall support the abili
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     Given I click on the link labeled "Add / Edit Records"

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0500. - Leave without Save.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0500. - Leave without Save.feature
@@ -22,7 +22,7 @@ Feature: Saving Data: The system shall support the prompt to save when a user at
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0600. - Save Options.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0600. - Save Options.feature
@@ -22,7 +22,7 @@ Feature: Saving Data: The system shall support the ability to: (Save and stay | 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL_REQUIREMENT:

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0700. - Form status options.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0700. - Form status options.feature
@@ -21,7 +21,7 @@ Feature: Saving Data: The system shall support the following statuses for data i
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0900. - Rename Record.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0900. - Rename Record.feature
@@ -22,7 +22,7 @@ Feature: Renaming a Record: The system shall allow users to rename a record.
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #SET UP_USER_RIGHTS

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1000. - Delete Form Data.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1000. - Delete Form Data.feature
@@ -22,7 +22,7 @@ Feature: B.3.14.1000. The system shall allow users to delete all data on the cur
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #SET UP_USER_RIGHTS

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1100. - Delete Record Data.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1100. - Delete Record Data.feature
@@ -22,7 +22,7 @@ Feature: B.3.14.1100. The system shall allow users to delete all data in an even
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #SET UP_USER_RIGHTS

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1200. - Delete Record.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1200. - Delete Record.feature
@@ -22,7 +22,7 @@ Feature: B.3.14.1200. The system shall allow users to delete a record from the R
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #SET UP_USER_RIGHTS

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0100. - Enable Instrument as Survey.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0100. - Enable Instrument as Survey.feature
@@ -25,7 +25,7 @@ Feature: User Interface: Survey Project Settings: The system shall support enabl
     #SETUP_PRODUCTION
     When I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0200. - Survey Status.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0200. - Survey Status.feature
@@ -21,7 +21,7 @@ Feature: User Interface: Survey Project Settings: The system shall support surve
     #SETUP_PRODUCTION
     When I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0300. - Survey Distribution Participant List.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0300. - Survey Distribution Participant List.feature
@@ -21,7 +21,7 @@ Feature: The system shall allow creation of a participant list automatically usi
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##VERIFY_SETUP

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0400. - Open Survey from Form.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0400. - Open Survey from Form.feature
@@ -22,7 +22,7 @@ Feature: User Interface: Survey Distribution: The system shall provide a survey 
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0500. - Survey Alerts and Prompts.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0500. - Survey Alerts and Prompts.feature
@@ -12,7 +12,7 @@ Feature: User Interface: Survey Distribution: The system shall prohibit the user
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #SETUP_RECORD

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0800. - Edit Survey Responses.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0800. - Edit Survey Responses.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall allow submitted survey responses to be
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##USER_RIGHTS - 1_FullRights

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0900. - Survey Response Status.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0900. - Survey Response Status.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall support the following statuses for sur
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #SETUP_DESIGNER

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1000. - Survey Participant List.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1000. - Survey Participant List.feature
@@ -12,7 +12,7 @@ Feature: User Interface: Survey Project Settings: The system shall support a par
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1100. - Survey Response Tracking.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1100. - Survey Response Tracking.feature
@@ -21,7 +21,7 @@ Feature: User Interface: Survey Project Settings: The system shall support track
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##VERIFY_SDT

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1200. - Disabled Survey Behavior.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1200. - Disabled Survey Behavior.feature
@@ -23,7 +23,7 @@ Feature: User Interface: Survey Project Settings: The system shall delete all su
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #SETUP: DESIGNER

--- a/Feature Tests/B/Draft Mode_20/A.4.20.0100. - REDUNDANT.feature
+++ b/Feature Tests/B/Draft Mode_20/A.4.20.0100. - REDUNDANT.feature
@@ -14,7 +14,7 @@ Feature: Control Center: The system shall allow production draft mode changes to
         # When I click on the link labeled "Project Setup"
         # And I click on the button labeled "Move project to production"
         # And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        # And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        # And I click on the button labeled "YES, Move to Production Status" in the dialog box
         # Then I should see Project status: "Production"
 
         # And I click on the link labeled "User Rights"

--- a/Feature Tests/B/Draft Mode_20/B.4.20.0300. - Instrument Behavior.feature
+++ b/Feature Tests/B/Draft Mode_20/B.4.20.0300. - Instrument Behavior.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall require changes made to data collectio
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/B/Draft Mode_20/B.4.20.0400. - Draft Mode Summary.feature
+++ b/Feature Tests/B/Draft Mode_20/B.4.20.0400. - Draft Mode Summary.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall provide detailed summary of all drafte
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##ACTION: Draft Mode

--- a/Feature Tests/B/Draft Mode_20/B.4.20.0500. - REDUNDANT.feature
+++ b/Feature Tests/B/Draft Mode_20/B.4.20.0500. - REDUNDANT.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall require administrators to review chang
 #     Given I click on the link labeled "Project Setup"
 #     And I click on the button labeled "Move project to production"
 #     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#     And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#     And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #     Then I should see Project status: "Production"
 
 #     When I click on the link labeled "Control Center"

--- a/Feature Tests/B/Draft Mode_20/B.4.20.0600. - REDUNDANT.feature
+++ b/Feature Tests/B/Draft Mode_20/B.4.20.0600. - REDUNDANT.feature
@@ -36,7 +36,7 @@ Feature: User Interface: The system shall provide the option to require administ
 #         Given I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         And I click on the link labeled "Logging"

--- a/Feature Tests/B/Draft Mode_20/B.4.20.0700. - REDUNDANT.feature
+++ b/Feature Tests/B/Draft Mode_20/B.4.20.0700. - REDUNDANT.feature
@@ -35,7 +35,7 @@ Feature: User Interface: The system shall allow administrators to commit changes
     #     Given I click on the link labeled "Project Setup"
     #     And I click on the button labeled "Move project to production"
     #     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    #     And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    #     And I click on the button labeled "YES, Move to Production Status" in the dialog box
     #     Then I should see Project status: "Production"
 
     #     And I click on the link labeled "Logging"
@@ -154,7 +154,7 @@ Feature: User Interface: The system shall allow administrators to commit changes
     #     Given I click on the link labeled "Project Setup"
     #     And I click on the button labeled "Move project to production"
     #     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    #     And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    #     And I click on the button labeled "YES, Move to Production Status" in the dialog box
     #     Then I should see Project status: "Production"
 
     #     When I click on the link labeled "Control Center"

--- a/Feature Tests/B/Draft Mode_20/B.4.20.0800. - Draft warning.feature
+++ b/Feature Tests/B/Draft Mode_20/B.4.20.0800. - Draft warning.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall flag any changes that may negatively i
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##ACTION: Draft Mode

--- a/Feature Tests/B/Draft Mode_20/B.4.20.0900. - Draft version control.feature
+++ b/Feature Tests/B/Draft Mode_20/B.4.20.0900. - Draft version control.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall record all versions of the data dictio
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #ACTION: Draft Mode

--- a/Feature Tests/B/Field Validation_8/B.4.8.0200. - Text Validation.feature
+++ b/Feature Tests/B/Field Validation_8/B.4.8.0200. - Text Validation.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support text validation for text field
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##VERIFY_CODEBOOK

--- a/Feature Tests/B/Field Validation_8/B.4.8.0300. - Field Ranges.feature
+++ b/Feature Tests/B/Field Validation_8/B.4.8.0300. - Field Ranges.feature
@@ -27,7 +27,7 @@ Feature: User Interface: The system shall support ranges for the following data 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #SETUP_DRAFT MODE

--- a/Feature Tests/B/Logging Module_23/B.2.23.0100. - Record Changes.feature
+++ b/Feature Tests/B/Logging Module_23/B.2.23.0100. - Record Changes.feature
@@ -14,7 +14,7 @@ Feature: User Interface: The logging module shall record all changes with userna
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Logging Module_23/B.2.23.0200. - Export Audit Trail.feature
+++ b/Feature Tests/B/Logging Module_23/B.2.23.0200. - Export Audit Trail.feature
@@ -14,7 +14,7 @@ Feature: User Interface: The logging module shall provide the ability to export 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Logging Module_23/B.2.23.0300. - Filtering Ability.feature
+++ b/Feature Tests/B/Logging Module_23/B.2.23.0300. - Filtering Ability.feature
@@ -19,7 +19,7 @@ Feature: User Interface: The logging module shall provide the ability to filter 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Logging Module_23/B.2.23.0400. - Module Security.feature
+++ b/Feature Tests/B/Logging Module_23/B.2.23.0400. - Module Security.feature
@@ -14,7 +14,7 @@ Feature: User Interface: The logging module shall be secure, tamper-proof, and n
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##USER_RIGHTS

--- a/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0100. - REDUNDANT.feature
+++ b/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0100. - REDUNDANT.feature
@@ -175,7 +175,7 @@ Feature: User Interface: The system shall allow the option to add or modify even
 #         And I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         When I click on the link labeled "Control Center"

--- a/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0200. - REDUNDANT.feature
+++ b/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0200. - REDUNDANT.feature
@@ -175,7 +175,7 @@ Feature: User Interface: The system shall provide the option to require administ
 #         And I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         When I click on the link labeled "Control Center"

--- a/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0300. - Enable & Disable Longitudinal Data Collection.feature
+++ b/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0300. - Enable & Disable Longitudinal Data Collection.feature
@@ -66,7 +66,7 @@ Feature: User Interface: Longitudinal Project Settings: The system shall support
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0400. - Event Designation.feature
+++ b/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0400. - Event Designation.feature
@@ -12,7 +12,7 @@ Feature: User Interface: Longitudinal Project Settings: The system shall support
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##SETUP

--- a/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0500. - REDUNDANT.feature
+++ b/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0500. - REDUNDANT.feature
@@ -15,7 +15,7 @@ Feature: User Interface: Longitudinal Project Settings: The system shall support
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         ##SETUP

--- a/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0600. - REDUNDANT.feature
+++ b/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0600. - REDUNDANT.feature
@@ -15,7 +15,7 @@ Feature: User Interface: Longitudinal Project Settings: The system shall support
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         ##SETUP

--- a/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0700. - delete events.feature
+++ b/Feature Tests/B/Longitudinal Project Setup_27/B.4.27.0700. - delete events.feature
@@ -17,7 +17,7 @@ Feature: User Interface: Longitudinal Project Settings: The system shall require
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ###USER_RIGHTS

--- a/Feature Tests/B/Online Designer_7/B.6.7.0300. - Rename Instrument.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0300. - Rename Instrument.feature
@@ -53,7 +53,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Online Designer_7/B.6.7.0400. - Copy Instrument.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0400. - Copy Instrument.feature
@@ -13,7 +13,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the button labeled "Online Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.0500. - Delete Instrument.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0500. - Delete Instrument.feature
@@ -24,7 +24,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the button labeled "Online Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.0600. - Reorder Instrument.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0600. - Reorder Instrument.feature
@@ -16,7 +16,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far." in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the button labeled "Online Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.0800. - Field Notes.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0800. - Field Notes.feature
@@ -22,7 +22,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
 
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.0900. - Field Calculated.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0900. - Field Calculated.feature
@@ -22,7 +22,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
 
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1000. - Field Multiple Choice.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1000. - Field Multiple Choice.feature
@@ -23,7 +23,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
     Given I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1100. - Field Radio.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1100. - Field Radio.feature
@@ -19,7 +19,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
         And I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1200. - Field Checkbox.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1200. - Field Checkbox.feature
@@ -18,7 +18,7 @@ Feature: Field Creation: The system shall support the creation of Checkboxes (mu
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1300. - Field Signature.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1300. - Field Signature.feature
@@ -18,7 +18,7 @@ Feature: Field Creation: The system shall support the creation of Signature (dra
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1400. - Field File Upload.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1400. - Field File Upload.feature
@@ -18,7 +18,7 @@ Feature: Field Creation: The system shall support the creation of File upload (f
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1500. - Field Descriptive Text.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1500. - Field Descriptive Text.feature
@@ -19,7 +19,7 @@ Feature: Field Creation: The system shall support the creation of Descriptive Te
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1600. - Field New Section.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1600. - Field New Section.feature
@@ -19,7 +19,7 @@ Feature: Field Creation: The system shall support the creation of Begin New Sect
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1800. - Required Fields.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1800. - Required Fields.feature
@@ -14,7 +14,7 @@ Feature: Field Creation: The system shall support marking a data entry field as 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         When I click on the link labeled "Designer"

--- a/Feature Tests/B/Online Designer_7/B.6.7.1900. - Field Management.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.1900. - Field Management.feature
@@ -33,7 +33,7 @@ Feature: Field Creation: The system shall support the ability to add, edit, copy
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
         And I logout
 

--- a/Feature Tests/B/Project Setup_4/B.6.4.1000. - Project Copy.feature
+++ b/Feature Tests/B/Project Setup_4/B.6.4.1000. - Project Copy.feature
@@ -80,7 +80,7 @@ Feature: User Interface: General: The system shall support the ability to copy t
     And I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Project Setup_4/B.6.4.1100. - Erase data in Development Mode.feature
+++ b/Feature Tests/B/Project Setup_4/B.6.4.1100. - Erase data in Development Mode.feature
@@ -46,7 +46,7 @@ Feature: User Interface: General: The system shall support the ability to erase 
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT
@@ -64,7 +64,7 @@ Feature: User Interface: General: The system shall support the ability to erase 
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##ACTION Verify record exist ##VERIFY_RSD

--- a/Feature Tests/B/Project Setup_4/B.6.4.1200. - Delete Project.feature
+++ b/Feature Tests/B/Project Setup_4/B.6.4.1200. - Delete Project.feature
@@ -54,7 +54,7 @@ Feature: User Interface: General: The system shall support the ability to delete
     And I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##ACTION Verify record do NOT exist ##VERIFY_RSD
@@ -82,7 +82,7 @@ Feature: User Interface: General: The system shall support the ability to delete
     And I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     ##ACTION Verify record exist ##VERIFY_RSD

--- a/Feature Tests/B/Project Setup_4/B.6.4.1400. - Repeating Surveys.feature
+++ b/Feature Tests/B/Project Setup_4/B.6.4.1400. - Repeating Surveys.feature
@@ -24,7 +24,7 @@ Feature: User Interface: Survey Project Settings: The system shall support the a
     #SETUP_PRODUCTION
     When I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I see Project status: "Production"
 
     #VERIFY_DESIGNER

--- a/Feature Tests/B/Project Status_11/B.6.11.0200. - Move project status.feature
+++ b/Feature Tests/B/Project Status_11/B.6.11.0200. - Move project status.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support the ability for a user to chan
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         ##VERIFY
         Then I should see Project status: "Production"
 

--- a/Feature Tests/B/Project Status_11/B.6.11.0300. - Data management during project status change.feature
+++ b/Feature Tests/B/Project Status_11/B.6.11.0300. - Data management during project status change.feature
@@ -16,7 +16,7 @@ Feature: User Interface: The system shall support the ability for a user to keep
         And I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         ##VERIFY
         Then I should see Project status: "Production"
 
@@ -42,7 +42,7 @@ Feature: User Interface: The system shall support the ability for a user to keep
         And I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Delete ALL data in the project" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         ##VERIFY
         Then I should see Project status: "Production"
 

--- a/Feature Tests/C/Data Quality_18/C.4.18.0100. - Data Quality default rules.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0100. - Data Quality default rules.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall provide default rules after installati
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/Data Quality_18/C.4.18.0200. - Data Quality create rules.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0200. - Data Quality create rules.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support data quality rule creation.
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/Data Quality_18/C.4.18.0300. - Data Quality execute rules.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0300. - Data Quality execute rules.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall support executing a rule.
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
         #FUNCTIONAL REQUIREMENT
         ##ACTION The system shall support executing a single rule.

--- a/Feature Tests/C/Data Quality_18/C.4.18.0400. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0400. - REDUNDANT.feature
@@ -15,7 +15,7 @@ Feature: User Interface: The system shall support executing all rules at the sam
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         #FUNCTIONAL_REQUIREMENT
@@ -44,7 +44,7 @@ Feature: User Interface: The system shall support executing all rules at the sam
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         ##ACTION executing all rules.

--- a/Feature Tests/C/Data Quality_18/C.4.18.0500. - Data Quality disrepancies.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0500. - Data Quality disrepancies.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall support viewing discrepancies found in
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         ##ACTION executing all rules.

--- a/Feature Tests/C/Data Quality_18/C.4.18.0600. - Data Quality exclude rules.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0600. - Data Quality exclude rules.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall support excluding discrepancies found 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status:  "Production"
 
         ##ACTION executing all rules.

--- a/Feature Tests/C/Data Quality_18/C.4.18.0700. - Data Quality edit rules.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0700. - Data Quality edit rules.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall support editing of user defined rules.
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status:  "Production"
         #USER_RIGHTS
         When I click on the link labeled "User Rights"

--- a/Feature Tests/C/Data Quality_18/C.4.18.0800. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0800. - REDUNDANT.feature
@@ -15,7 +15,7 @@ Feature: User Interface: The system shall support the deletion of a user defined
 #     When I click on the link labeled "Project Setup"
 #     And I click on the button labeled "Move project to production"
 #     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#     And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#     And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #     Then I should see Project status: "Production"
 
 #     #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/Data Quality_18/C.4.18.0900. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0900. - REDUNDANT.feature
@@ -14,7 +14,7 @@ Feature: User Interface: The system shall support clearing discrepancies from ru
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status:  "Production"
 
 #         ##ACTION executing all rules.

--- a/Feature Tests/C/Data Quality_18/C.4.18.1000. - Data Quality realtime.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.1000. - Data Quality realtime.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support the ability to run custom data
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #SETUP_PRODUCTION: Rule Creation

--- a/Feature Tests/C/Data Quality_18/C.4.18.1100. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.1100. - REDUNDANT.feature
@@ -15,7 +15,7 @@ Feature: User Interface: The system shall support validating the unique event na
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/Data Quality_18/C.4.18.1200. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.1200. - REDUNDANT.feature
@@ -14,7 +14,7 @@ Feature: User Interface: The system shall support removal of exclusion of discre
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status:  "Production"
 
 #         ##ACTION executing all rules.

--- a/Feature Tests/C/Data Quality_18/C.4.18.1300. - Data Quality DAG.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.1300. - Data Quality DAG.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support limiting rule viewing to a Dat
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #USER_RIGHTS

--- a/Feature Tests/C/Data Quality_18/C.4.18.1400. - Data Quality support user rights.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.1400. - Data Quality support user rights.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support limiting a rule viewing that r
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #USER_RIGHTS: add two users with diff access levels

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0100. - Lock status.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0100. - Lock status.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The E-signature and Locking Management tool shall displ
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #SETUP

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0200. - Lock form display.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0200. - Lock form display.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The tool shall only display forms that are designated t
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: #SETUP form lock to display

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0300. - Locking record filter.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0300. - Locking record filter.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The tool shall support the filtering the record list:
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0400. - Lock status display.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0400. - Lock status display.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The tool shall display locked status of forms for all r
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #USER_RIGHTS

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0500. - eSign display.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0500. - eSign display.feature
@@ -14,7 +14,7 @@ Feature: User Interface: The tool shall display e-signature status of forms for 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #USER_RIGHTS

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0600. - Locking module navigation.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0600. - Locking module navigation.feature
@@ -14,7 +14,7 @@ Feature: User Interface: The tool shall support the ability to navigate directly
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
  
         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0700. - eSign customization.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0700. - eSign customization.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The Record Locking Customization module shall allow the
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0800. - REDUNDANT.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0800. - REDUNDANT.feature
@@ -17,7 +17,7 @@ Feature: User Interface: The Record Locking Customization module shall provide t
 #         When I click on the link labeled "Project Setup"
 #         And I click on the button labeled "Move project to production"
 #         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#         And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #         Then I should see Project status: "Production"
 
 #         #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0900. - eSign and Lock access.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0900. - eSign and Lock access.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall support the ability to limit access to
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
     Scenario: #SETUP

--- a/Feature Tests/C/Reporting_22/C.5.22.0100. - Report Access.feature
+++ b/Feature Tests/C/Reporting_22/C.5.22.0100. - Report Access.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support the ability to assign the User
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: #USER_RIGHTS User 1 Dag 1

--- a/Feature Tests/C/Reporting_22/C.5.22.0200. - Report Management.feature
+++ b/Feature Tests/C/Reporting_22/C.5.22.0200. - Report Management.feature
@@ -12,7 +12,7 @@ Feature: User Interface:  The system shall support the ability to create, modify
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
     #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0105. - eConsent enable.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0105. - eConsent enable.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support the enabling of the e-Consent 
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
     #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0205. - eConsent footer.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0205. - eConsent footer.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support the e-Consent Framework abilit
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
     Scenario: #SETUP_eConsent for participant consent process

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0305. - eConsent status.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0305. - eConsent status.feature
@@ -13,7 +13,7 @@ Feature: C.3.24.0305. User Interface: The system shall support the e-Consent Fra
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
 

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0405. - eConsent goverend snapshot.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0405. - eConsent goverend snapshot.feature
@@ -13,7 +13,7 @@ Feature:  C.3.24.0405. User Interface: The system shall support the e-Consent Fr
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
     Scenario: Verify eConsent Framework and PDF Snapshot setup

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0505. - eConsent download PDF.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0505. - eConsent download PDF.feature
@@ -12,7 +12,7 @@ Feature: C.3.24.0505. User Interface: The system shall support the e-Consent Fra
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
     Scenario: Verify eConsent Framework and PDF Snapshot setup

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0605. - eConsent edit.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0605. - eConsent edit.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The e-Consent framework shall support editing of respon
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
 

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0705. - eConsent Certification Page.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0705. - eConsent Certification Page.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to pro
         When I click on the link labeled "Project Setup"
         And I click on the button labeled "Move project to production"
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+        And I click on the button labeled "YES, Move to Production Status" in the dialog box
         Then I should see Project status: "Production"
 
     Scenario: add record with consent framework

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0805. - eConsent repeat.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0805. - eConsent repeat.feature
@@ -56,7 +56,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for re
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: add record with consent framework

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1200. - eConsent header.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1200. - eConsent header.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to cre
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: #SETUP_eConsent for custom header

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1300. - eConsent filename.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1300. - eConsent filename.feature
@@ -10,7 +10,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to cus
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
       #SETUP_eConsent for participant consent process
       #SETUP_eConsent for participant consent process

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1400. - eConsent custom note.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1400. - eConsent custom note.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to cre
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
       #SETUP_eConsent for participant consent process

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1500. - eConsent version control.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1500. - eConsent version control.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for ve
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: Cancel an add consent form version

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1600. - eConsent field.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1600. - eConsent field.feature
@@ -11,7 +11,7 @@ Given This scenario is fully tested within C.3.24.1500.
 #       When I click on the link labeled "Project Setup"
 #       And I click on the button labeled "Move project to production"
 #       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-#       And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+#       And I click on the button labeled "YES, Move to Production Status" in the dialog box
 #       Then I should see Project status: "Production"
 #       When I click on the button labeled "+Add consent form" for the survey labeled "Participant Consent"
 #       Then I should see "Consent form version"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1700. - eConsent DAG.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1700. - eConsent DAG.feature
@@ -11,7 +11,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to lim
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: Cancel an add consent form version

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1900. - eConsent autosave PDF.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1900. - eConsent autosave PDF.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to opt
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
    Scenario: #SETUP_eConsent for participant consent process

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2000. - eConsent display.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2000. - eConsent display.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to hid
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
    #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2100. - eConsent search.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2100. - eConsent search.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to sea
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
       #FUNCTIONAL_REQUIREMENT

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2200. - PDF triggers.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2200. - PDF triggers.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support the creation, modification, an
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
       When I click on the button lanbeled "Designer"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2500. - PDF conditional logic.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2500. - PDF conditional logic.feature
@@ -10,7 +10,7 @@ Feature: User Interface: The system shall support conditional logic integration 
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: New PDF Trigger testing Every time the following survey is completed

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2600. - PDF multi.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2600. - PDF multi.feature
@@ -36,7 +36,7 @@ Feature: User Interface: The system shall support the capture and storage of mul
     When I click on the link labeled "Project Setup"
     And I click on the button labeled "Move project to production"
     And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box
     Then I should see Project status: "Production"
 
   Scenario: New multi data form same event PDF Trigger

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2700. - PDF save location.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2700. - PDF save location.feature
@@ -13,7 +13,7 @@ Feature: User Interface: The system shall support the saving PDF snapshots to sp
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
       When I click on the button lanbeled "Designer"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2800. - PDF filename.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2800. - PDF filename.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support the customization of the file 
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
       When I click on the button lanbeled "Designer"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2900. - eConsent PDF logging.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2900. - eConsent PDF logging.feature
@@ -12,7 +12,7 @@ Feature: User Interface: The system shall support audit trails for e-Consent Cer
       When I click on the link labeled "Project Setup"
       And I click on the button labeled "Move project to production"
       And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-      And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+      And I click on the button labeled "YES, Move to Production Status" in the dialog box
       Then I should see Project status: "Production"
 
    Scenario: #SETUP_eConsent for participant consent process


### PR DESCRIPTION
@4bbakers, I don't expect you to review every line here, as they are all the same.  This PR removes the extraneous `to request a change in project status` text from the end of most of our `Move to Production` steps.  Comparing the following cloud build results confirms that this change has no affect on automation results:

![image](https://github.com/user-attachments/assets/76d0360a-69e4-45ab-ae40-304983519225)
