### PR TITLE
Cause a hanging test to fail gracefully

### DIFF
--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0305. - eConsent status.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0305. - eConsent status.feature
@@ -22,6 +22,7 @@ Feature: C.3.24.0305. User Interface: The system shall support the e-Consent Fra
         When I click on the link labeled "Designer"
         And I click on the button labeled "e-Consent"
         And I click on the button labeled "Enable the e-Consent Framework for a survey"
+        And I determine why the following step is causing cypress builds to hang before removing this line
         And I select '"Participant Consent" (participant_consent)' in the dropdown field labeled "Enable e-Consent for a Survey" in the dialog box
         Then I should see "Enable e-Consent" in the dialog box
         And I should see "Primary settings"


### PR DESCRIPTION
This avoids the `Too long with no output (exceeded 10m0s): context deadline exceeded` in CircleCI from causing builds to be reported as taking hours in Cypress even though they fail after minutes.  This features has never passed automation, and is on our list to work on.  This PR is a stop gap to ensure normal build output until we can look into this feature in general. 