### PR TITLE
Changes to A.3.30.0100.

### DIFF
--- a/Feature Tests/A/Randomization_30/A.3.30.0100. - Randomization system enable.feature
+++ b/Feature Tests/A/Randomization_30/A.3.30.0100. - Randomization system enable.feature
@@ -18,8 +18,9 @@ Feature: A.3.30.0100 Control Center: The system shall support enabling or disabl
     #SETUP
     Given I create a new project named "A.3.30.0100." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button
     Then I should see "Main project settings"
-    And I should see "Randomization Module"
-
+    And I click on the link labeled "Project Setup"
+    Then I should see a button labeled "Enable" in the "Randomization module" row in the "Enable optional modules and customizations" section
+    
   #A.3.30.0100.0200: Disabled at system level removes randomization module option at the project level.
   Scenario: A.3.30.0100.0200. Disable randomization at system level
     #FUNCTIONAL_REQUIREMENT
@@ -35,6 +36,7 @@ Feature: A.3.30.0100 Control Center: The system shall support enabling or disabl
     #SETUP
     When I click on the link labeled "My Projects"
     And I click on the link labeled "A.3.30.0100."
-    And I should NOT see "Randomization Module"
+    And I click on the link labeled "Project Setup"
+    Then I should NOT see "Randomization module"
     And I logout
 #END


### PR DESCRIPTION
The test needed slight wording changes so that it would accurately test that the system shall support enabling or disabling the Randomization module system-wide through automation. With these changes the test works with automation and appropriately hides or shows the ability to activate randomization at the project level when activated accordingly at the system level.