### PR TITLE
Updates to C.3.30.0200

### DIFF
--- a/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
@@ -1,20 +1,36 @@
 Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling Randomization at the project level.
-  As a REDCap end user
-  I want to see that Randomization is functioning as expected
+  As a REDCap end user I want to see that Randomization is functioning as expected
 
-  Scenario: Randomization enabled
-    #SETUP
+  Scenario: Setup
+     #SETUP project with no randomization enabled
     Given I login to REDCap with the user "Test_User1"
-    And I create a new project named "C.3.30.0200.0100" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "cdisc_files/Project 3.30 norand.REDCap.xml", and clicking the "Create Project" button
-    #FUNCTIONAL_REQUIREMENT
-    And I click on the button labeled "Enable" in the "Randomization module" row in the "Enable optional modules and customizations" section
-    ##VERIFY C.3.30.0200.0100. Enabling adds randomization module to project setup
-    ##VERIFY C.3.30.0200.0200. Enabling adds randomization module to application box
-    Then I should see a button labeled "Disable" in the "Randomization module" row in the "Enable optional modules and customizations" section
-    And I should see "Set up a randomization model"
-  #While the "Set up a randomization model" button is visible, it will be disabled (greyed out).
+    And I create a new project named "C.3.30.0700." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button
+     #SETUP User Rights
+    When I click on the link labeled "User Rights"
+    And I click on the link labeled "Test User1"
+    And I click on the button labeled "Assign to role" on the tooltip
+    And I select "1_FullRights" on the dropdown field labeled "Select Role"
+    And I click on the button labeled exactly "Assign"
+    Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
 
-  Scenario: ##VERIFY_log Randomization at project level enabled recorded in logging table
+  Scenario: C.3.30.0200.0100. Enabling adds randomization module to project setup.
+    When I click on the link labeled "Project Setup"
+    And I click on the button labeled "Enable" in the "Randomization module" row in the "Enable optional modules and customizations" section
+     ##VERIFY Enabling adds randomization module to project setup.
+    And I should see a button labeled "Disable" in the "Randomization module" row in the "Enable optional modules and customizations" section
+    And I should see "Set up a randomization model"
+
+     #VERIFY _log Enabling adds randomization module to project setup.
+    When I click on the link labeled "Logging"
+    Then I should see a table header and rows containing the following values in the logging table:
+      | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
+      | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Modify project settings                 |
+
+  Scenario: C.3.30.0200.0200. Enabling adds randomization module to application box
+    When I click on the link labeled "Project Setup"
+    Then I should see a button labeled "Set up randomization"
+
+     #VERIFY Enabling adds randomization module to application box
     When I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
       | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
@@ -22,90 +38,44 @@ Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling R
 
   Scenario: C.3.30.0200.0300. Enabling adds randomization module options Setup, Dashboard, and Randomize to user rights privilege setup page.
     When I click on the link labeled "User Rights"
-    ##VERIFY
-    Then I should see a table header and rows containing the following values in a table:
-      | Role name               | Username            |
-      | —                       | test_user1          |
-      | 1_FullRights            | [No users assigned] |
-      | 2_Edit_RemoveID         | [No users assigned] |
-      | 3_ReadOnly_Deidentified | [No users assigned] |
-      | 4_NoAccess_Noexport     | [No users assigned] |
-      | TestRole                | [No users assigned] |
-
-    When I click on the link labeled "Test User1"
+    And I click on the link labeled "Test User1" 
+    And I click on the button labeled "Remove from role"
+    And I click on the button labeled "Close" in the dialog box
+    And I click on the link labeled "Test User1" 
     And I click on the button labeled "Edit user privileges"
-    Then I should see a dialog containing the following text: "Editing existing user"
-    And I should see "Randomization"
-    When  I check the checkbox labeled "Setup"
-    And I check the checkbox labeled "Dashboard"
-    And I check the checkbox labeled "Randomize"
-    And I save changes within the context of User Rights
-    #refresh
-    Then I should see a link labeled "Randomization"
-
-  Scenario: #SETUP Randomization
-    #C.3.30.0300.0100. User with Randomization Setup rights can use Randomization Module Setup Configuration page.
-    #C.3.30.0400.0100. User with Randomization Dashboard rights can use Randomization Module Dashboard page.
-    When I click on the link labeled "Randomization"
-    ##VERIFY User with Randomization Setup rights can use Randomization Module Setup Configuration page.
-    When I click on a button labeled "Add new randomization model"
-    Then I should see  "STEP 1: Define your randomization model"
-
-    When I select "rand_group" from the dropdown labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomizatoin module"
-    And I upload a "csv" format file located at "import_files/AlloRand1.csv", by clicking the button near "Upload allocation table (CSV file) for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
-    Then I should see "Delete allocation table?"
+    Then I should see "Randomization"
     And I should see "Setup"
     And I should see "Dashboard"
-
-    When I click the link labeled "Dashboard"
-    Then I should see "table below displays the allocation dashboard"
-
-  Scenario: Disable Randomization Dashboard
-    #C.3.30.0200.0600. Disabling removes randomization module options Setup, Dashboard, and Randomize to user rights privilege setup page.
-    #C.3.30.0400.0200. User without Randomization Dashboard rights cannot use Randomization Module Dashboard page.
-    When I click on the link labeled "User Rights"
-    And I click on the link labeled "Test User1"
-    And I click on the button labeled "Edit user privileges"
-    Then I should see a dialog containing the following text: "Editing existing user"
-
-    When  I check the checkbox labeled "Setup"
-    And I uncheck the checkbox labeled "Dashboard"
-    And I check the checkbox labeled "Randomize"
-    And I save changes within the context of User Rights
-
-    When I click on the link labeled "Randomization"
-    Then I should see "Setup"
-    And I should NOT see "Dashboard"
-
-  Scenario: Disable Randomization Setup
-    #C.3.30.0300.0200. User without Randomization Setup rights cannot use Randomization Module Setup Configuration page.
-    When I click on the link labeled "User Rights"
-    And I click on the link labeled "Test User1"
-    And I click on the button labeled "Edit user privileges"
-    Then I should see a dialog containing the following text: "Editing existing user"
-
-    When  I uncheck the checkbox labeled "Setup"
-    And I uncheck the checkbox labeled "Dashboard"
-    And I check the checkbox labeled "Randomize"
-    And I save changes within the context of User Rights
-
-    When I click on the link labeled "Randomization"
-    Then I should see "ACCESS DENIED!"
-    And I should NOT see "Setup"
-    And I should NOT see "Dashboard"
-    #refresh
-    #C.3.30.0200.0500. Disabling removes randomization module from application box.
-    And i should NOT see "randomization"
+    And I should see "Randomize"
+    And I click on the button labeled "Cancel" on the dialog box
 
   Scenario: C.3.30.0200.0400. Disabling removes randomization module from project setup
     When I click on the link labeled "Project Setup"
-    Then I should see "Disable" in the "Randomization module" row in the "Enable optional modules and customizations" section
-
+    Then I should see a button labeled "Disable" in the "Randomization module" row in the "Enable optional modules and customizations" section
     When I click on the button labeled "Disable" in the "Randomization module" row in the "Enable optional modules and customizations" section
-    ##VERIFY Randomization at project level disabled
-    #refresh
-    Then I should see "Enable" in the "Randomization module" row in the "Enable optional modules and customizations" section
+     #VERIFY Disabling removes randomization module from project setup
+    Then I should see a button labeled "Enable" in the "Randomization module" row in the "Enable optional modules and customizations" section
+    And I should NOT see "Set up a randomization model" 
+    When I click on the link labeled "Logging"
+    Then I should see a table header and rows containing the following values in the logging table:
+      | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
+      | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Modify project settings                 |
+
+  Scenario: C.3.30.0200.0500. Disabling removes randomization module from application box.
+    When I click on the link labeled "Project Setup"
+    Then I should see a button labeled "Enable" in the "Randomization module" row in the "Enable optional modules and customizations" section
+     #VERIFY Disabling removes randomization module from application box.
+    And I should NOT see a link labeled "Randomization"
     And I should NOT see "Set up a randomization model"
+
+  Scenario: C.3.30.0200.0600. Disabling removes randomization module options Setup, Dashboard, and Randomize to user rights privilege setup page.
+    When I click on the link labeled "User Rights"
+    And I click on the link labeled "1_FullRights"
+     #VERIFY options Setup, Dashboard, and Randomize NOT in user rights privilege setup page.
+    Then I should NOT see "Randomization"
+    And I should NOT see a checkbox labeled "Setup"
+    And I should NOT see a checkbox labeled "Dashboard"
+    And I should NOT see a checkbox labeled "Randomize"
+    And I click on the button labeled "Cancel" on the dialog box
     And I logout
 #END

--- a/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
@@ -4,7 +4,7 @@ Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling R
   Scenario: Setup
      #SETUP project with no randomization enabled
     Given I login to REDCap with the user "Test_User1"
-    And I create a new project named "C.3.30.0700." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button
+    And I create a new project named "C.3.30.0200." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button
      #SETUP User Rights
     When I click on the link labeled "User Rights"
     And I click on the link labeled "Test User1"

--- a/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
@@ -1,7 +1,7 @@
 Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling Randomization at the project level.
   As a REDCap end user I want to see that Randomization is functioning as expected
 
-  Scenario: Setup
+  Scenario: #SETUP project
      #SETUP project with no randomization enabled
     Given I login to REDCap with the user "Test_User1"
     And I create a new project named "C.3.30.0200." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button


### PR DESCRIPTION
This PR is to update Feature: [C.3.30.0200. - Randomization project enable](https://github.com/4bbakers/redcap_rsvc/tree/staging/Feature%20Tests/C/Randomization_30/C.3.30.0200.%20-%20Randomization%20project%20enable.feature)

Within this PR you will find modifications to ensure all tests (see list below) are properly written in a way to pass both manual and automated testing for the enabling and disabling of the randomization feature in REDCap. These features specifically look at the user interface and if certain randomization features become available when randomization is on or off.

#Scenario: C.3.30.0200.0100.Enabling adds randomization module to project setup.  
#Scenario: C.3.30.0200.0200. Enabling adds randomization module to application box.  
#Scenario: C.3.30.0200.0300. Enabling adds randomization module options Setup, Dashboard, and Randomize to user rights privilege setup page.  
#Scenario: C.3.30.0200.0400. Disabling removes randomization module from project setup.  
#Scenario: C.3.30.0200.0500. Disabling removes randomization module from application box.  
#Scenario: C.3.30.0200.0600. Disabling removes randomization module options Setup, Dashboard, and Randomize to user rights privilege setup page.

