### PR TITLE
Add shell scripts to facilitate upload of lines added/removed for each Gherkin feature within RSVC REDCap repo

### DIFF
--- a/find_feature_changes.sh
+++ b/find_feature_changes.sh
@@ -128,7 +128,7 @@ END {
         printf "%10d %10d %10d   %s - UPLOADED\n", file_added, file_deleted, file_total, feature;
       } else {
         # Use the normalized feature name
-        printf "%10d %10d %10d   %s\n", file_added, file_deleted, file_total, feature;
+        printf "%10d %10d %10d   %s\n", file_added, file_deleted, file_total, file;
       }
   }
   printf "%s\n", "---------------------------------------------------------------";

--- a/find_feature_changes.sh
+++ b/find_feature_changes.sh
@@ -111,8 +111,19 @@ END {
       # Generate the feature name
       feature = letter "." part1 "." part2 "." part3 ".";
 
+      # Figure out estimated modified lines
+      mod = (file_added < file_deleted ? file_added : file_deleted);
+      pure_added = file_added - mod;
+      pure_deleted = file_deleted - mod;
+
       if (upload == "true") {
-        cmd = "sh push_lines_changes.sh \"" feature "\" " file_added " " file_deleted " " file_total;
+        cmd = "sh push_lines_changes.sh \"" feature "\" " \
+              file_added " " \
+              pure_added " " \
+              file_deleted " " \
+              pure_deleted " " \
+              file_total " " \
+              mod;
         system(cmd)
         printf "%10d %10d %10d   %s - UPLOADED\n", file_added, file_deleted, file_total, feature;
       } else {

--- a/find_feature_changes.sh
+++ b/find_feature_changes.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Default values
+prompt_mode=false
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --cur_tag)
+      CUR_TAG="$2"
+      shift 2
+      ;;
+    --comp_tag)
+      COMP_TAG="$2"
+      shift 2
+      ;;
+    --start_date)
+      START_DATE="$2"
+      shift 2
+      ;;
+    --end_date)
+      END_DATE="$2"
+      shift 2
+      ;;
+    --prompt)
+      prompt_mode=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Handle prompt mode
+if [[ "$prompt_mode" = true ]]; then
+  echo "Choose Mode"
+  echo "1) Tags"
+  echo "2) Dates"
+  read -rp "Enter 1 or 2: " choice
+
+  case "$choice" in
+    1)
+      read -rp "Enter current tag: " CUR_TAG
+      read -rp "Enter comparison tag: " COMP_TAG
+      ;;
+    2)
+      read -rp "Enter start date (YYYY-MM-DD): " START_DATE
+      read -rp "Enter end date (YYYY-MM-DD): " END_DATE
+      ;;
+    *)
+      echo "Invalid choice. Exiting."
+      exit 1
+      ;;
+  esac
+fi
+
+awk_script='$3 ~ /\.feature$/ {
+  added[$3] += $1;
+  deleted[$3] += $2;
+  files[$3] = 1;
+}
+END {
+  total_added = 0;
+  total_deleted = 0;
+  printf "%10s %10s %10s   %s\n", "Added", "Deleted", "Total", "File";
+  for (file in files) {
+    file_added = added[file];
+    file_deleted = deleted[file];
+    file_total = file_added + file_deleted;
+    total_added += file_added;
+    total_deleted += file_deleted;
+    printf "%10d %10d %10d   %s\n", file_added, file_deleted, file_total, file;
+  }
+  printf "%s\n", "---------------------------------------------------------------";
+  printf "%10d %10d %10d   %s\n", total_added, total_deleted, total_added + total_deleted, "TOTAL";
+}'
+
+
+# Validate input
+if [[ -n "$CUR_TAG" && -n "$COMP_TAG" ]]; then
+  echo "Using tags: CURRENT_TAG=$CUR_TAG vs COMPARISON_TAG=$COMP_TAG"
+
+    #Only if empty Start Date
+    if [ -z $START_DATE ]; then
+      START_DATE=$(git log -1 --format=%ad --date=short $COMP_TAG)
+    fi
+
+    #Only if empty End Date
+    if [ -z $END_DATE ]; then
+      END_DATE=$(git log -1 --format=%ad --date=short $CUR_TAG)
+    fi
+
+elif [[ -n "$START_DATE" && -n "$END_DATE" ]]; then
+  echo "Using dates: START_DATE=$START_DATE => END_DATE=$END_DATE"
+
+else
+  #Only if empty Current Tag
+  if [ -z $CUR_TAG ]; then
+    CUR_TAG=$(git tag --sort=-v:refname | head -n 1)
+  fi
+
+  #Only if empty Comparison Tag
+  if [ -z $COMP_TAG ]; then
+    COMP_TAG=$(git tag --sort=-creatordate | sed -n 2p)
+  fi
+
+  #Only if empty Start Date
+  if [ -z $START_DATE ]; then
+    START_DATE=$(git log -1 --format=%ad --date=short $COMP_TAG)
+  fi
+
+  #Only if empty End Date
+  if [ -z $END_DATE ]; then
+    END_DATE=$(git log -1 --format=%ad --date=short $CUR_TAG)
+  fi
+
+  echo "DEFAULT MODE: Takes the most recent tag and compares it to the previous tag.\n"
+
+fi
+
+# Get the line changes for .feature files between the dates
+git log --since="$START_DATE" --until="$END_DATE" --pretty=tformat: --numstat --ignore-space-change | awk -F'\t' "$awk_script"
+
+if [ -z $CUR_TAG ]; then
+  echo ""
+else
+  echo "\nTAGS: \n CURRENT_TAG: $CUR_TAG \n COMPARISON_TAG: $COMP_TAG\n"
+fi
+echo "DATES:\n START_DATE: $START_DATE \n END_DATE: $END_DATE\n"

--- a/find_feature_changes.sh
+++ b/find_feature_changes.sh
@@ -5,9 +5,11 @@ if [ -f .env ]; then
   source .env
 fi
 
-if [ -z "$REDCAP_API_TOKEN" ]; then
-  echo "Environment variable REDCAP_API_TOKEN is not set. Exiting."
-  exit 1
+if [ "$upload" = true ]; then
+  if [ -z "$REDCAP_API_TOKEN" ]; then
+    echo "Environment variable REDCAP_API_TOKEN is not set. Exiting."
+    exit 1
+  fi
 fi
 
 # Default values

--- a/find_feature_changes.sh
+++ b/find_feature_changes.sh
@@ -112,6 +112,8 @@ END {
       feature = letter "." part1 "." part2 "." part3 ".";
 
       if (upload == "true") {
+        cmd = "sh push_lines_changes.sh \"" feature "\" " file_added " " file_deleted " " file_total;
+        system(cmd)
         printf "%10d %10d %10d   %s - UPLOADED\n", file_added, file_deleted, file_total, feature;
       } else {
         # Use the normalized feature name

--- a/push_lines_changes.sh
+++ b/push_lines_changes.sh
@@ -3,8 +3,11 @@ CURL=`which curl`
 
 FEATURE="$1"
 ADDED="$2"
-DELETED="$3"
-TOTAL="$4"
+PURE_ADDED="$3"
+DELETED="$4"
+PURE_DELETED="$5"
+TOTAL="$6"
+TOTAL_MOD="$7"
 
 # Load environment variables from .env file
 if [ -f .env ]; then
@@ -23,6 +26,6 @@ $CURL -X POST "$REDCAP_API_URL" \
   -d "content=record" \
   -d "format=json" \
   -d "type=flat" \
-  -d "data=[{\"record_id\":\"$FEATURE\",\"lines_added\":\"$ADDED\",\"lines_removed\":\"$DELETED\",\"total_lines_changed\":\"$TOTAL\",\"feature_changes_complete\":\"2\"}]" \
+  -d "data=[{\"record_id\":\"$FEATURE\",\"lines_added\":\"$ADDED\",\"lines_added_pure\":\"$PURE_ADDED\",\"lines_removed\":\"$DELETED\",\"lines_removed_pure\":\"$PURE_DELETED\",\"total_lines_changed\":\"$TOTAL\",\"est_total_mod_lines\":\"$TOTAL_MOD\",\"feature_changes_complete\":\"2\"}]" \
   -d "returnContent=ids" \
   -d "returnFormat=json"

--- a/push_lines_changes.sh
+++ b/push_lines_changes.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+CURL=`which curl`
+
+FEATURE="$1"
+ADDED="$2"
+DELETED="$3"
+TOTAL="$4"
+
+# Load environment variables from .env file
+if [ -f .env ]; then
+  source .env
+fi
+
+if [ -z "$REDCAP_API_TOKEN" ]; then
+  echo "Environment variable REDCAP_API_TOKEN is not set. Exiting."
+  exit 1
+fi
+
+#Upload the Video file to the REDCap project
+$CURL -X POST "$REDCAP_API_URL" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "token=$REDCAP_API_TOKEN" \
+  -d "content=record" \
+  -d "format=json" \
+  -d "type=flat" \
+  -d "data=[{\"record_id\":\"$FEATURE\",\"lines_added\":\"$ADDED\",\"lines_removed\":\"$DELETED\",\"total_lines_changed\":\"$TOTAL\",\"feature_changes_complete\":\"2\"}]" \
+  -d "returnContent=ids" \
+  -d "returnFormat=json"


### PR DESCRIPTION
# Pre-flight Checklist
- [X] Are all the features in this PR tested? 
- [ ] Have other features this PR touches also been tested?
- [X] Has the code been formatted for consistency and readability?
- [ ] Did you also update related documentation and tooling, such as .readme or tests?  

_It would make sense to do this if we decide to go this route._ Draft PR for now.  Please see screenshots for an idea of how to use this.  It's pretty straight-forward but open to feedback and changes if necessary.

# Overview
This code enables per-Gherkin-feature lines added / removed data and the automated upload of results the Regulatory and Software Validation REDCap project to the Online Designer instrument called "Feature Changes". 

Data provided to REDCap projects is currently limited to [Gherkin features within A, B, or C folders](https://github.com/aldefouw/redcap_rsvc/blob/staging/find_feature_changes.sh#L133).  That could easily be changed.  

**It depends upon the following fields in the project within VUMC REDCap:**
- **[lines_added]** | Gherkin Lines Added Since Previous LTS | text (number)
- **[lines_added_pure]** | Gherkin Lines - Pure Added | text (number)
- **[lines_removed]** | Gherkin Lines Removed Since Previous LTS | text (number)
- **[lines_removed_pure]** | Gherkin Lines - Pure Removed | text (number)
- **[total_lines_changed]** | Total Gherkin Lines Changed Since Previous LTS | text (number)
- **[est_total_mod_lines]** | Estimated Gherkin Lines Modified Since Previous LTS | text (number)
- **[feature_changes_complete]**

**It also depends upon an API key specific to the REDCap version tied the Functional Requirements project.**  

For example, API keys for each:

- https://redcap.vumc.org/redcap_v15.4.4/index.php?pid=196119
- https://redcap.vumc.org/redcap_v15.4.4/index.php?pid=204685

Thus, you need to update the API key before a push.

<!--Provide a summary  of this pr. Is this a new module? A new feature? a bug fix? a code reformat?-->



# Screenshots

**- Default behavior:**
![Screenshot 2025-06-19 at 9 42 57 AM](https://github.com/user-attachments/assets/0013b10d-fde4-4dcf-add1-b8c36aab880e)

![Screenshot 2025-06-19 at 9 56 38 AM](https://github.com/user-attachments/assets/5f4c33d7-b2fc-438b-a149-ac946224501d)

This default mode will choose the **most recent tag** and the **next most recent tag** as a point of comparison.

**- Prompt mode (Tag):**
![Screenshot 2025-06-19 at 9 43 57 AM](https://github.com/user-attachments/assets/9018dbe7-75db-489d-97c4-a84c3ee377f8)

**- Prompt mode (Date):**
![Screenshot 2025-06-19 at 9 44 40 AM](https://github.com/user-attachments/assets/e00ef67d-054b-481b-81eb-40053e2d2602)

**- CLI mode (Tag):**
![Screenshot 2025-06-19 at 9 45 31 AM](https://github.com/user-attachments/assets/00fc57d6-c1bc-4d7d-9929-a3949499d4dd)

**- CLI mode (Date):**
![Screenshot 2025-06-19 at 9 46 24 AM](https://github.com/user-attachments/assets/1298c519-0c33-4706-94e5-6d2c25336be6)

**- Upload Mode:**
![Screenshot 2025-06-19 at 9 47 45 AM](https://github.com/user-attachments/assets/1a65747f-5c43-4bab-aec1-a8c7d46339b1)

Using **--upload** will upload the results if the API is available AND the data instrument is available within that project which the API key exists.

This mode requires the **REDCAP_API_TOKEN** to be set as an environment variable.
