### PR TITLE
Updates to C.3.30 per feedback

### DIFF
--- a/Feature Tests/C/Randomization_30/C.3.30.1100. - Randomization rights execute.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1100. - Randomization rights execute.feature
@@ -74,6 +74,23 @@ Feature: C.3.30.1100.	User Interface: The system shall ensure users with Randomi
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 2 successfully edited."
 
+    #Verify "Randomization group" field is populated with an expected value (i.e., what was selected from the allocation table).
+    When I click on the link labeled "Add / Edit Records"
+    And I select "2" on the dropdown field labeled "Choose an existing Record ID"
+    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+    Then I should see "Already randomized"
+    And I should see a radio labeled "Drug A" in the row labeled "Already randomized" that is disabled
+    And I should see a radio labeled "Drug B" in the row labeled "Already randomized" that is disabled
+    And I should see a radio labeled "Placebo" in the row labeled "Already randomized" that is disabled
+
+    When I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
+    And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
+    Then I should see a table header and rows containing the following values in a table:
+            |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
+            |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
+	          |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        | 
+
   Scenario: C.3.30.1100.0300. Record's randomized value matches allocation table.  
     # This feature test is REDUNDANT and can be viewed in C.3.30.0200 and C.3.30.0300
 

--- a/Feature Tests/C/Randomization_30/C.3.30.1100. - Randomization rights execute.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1100. - Randomization rights execute.feature
@@ -89,7 +89,7 @@ Feature: C.3.30.1100.	User Interface: The system shall ensure users with Randomi
     Then I should see a table header and rows containing the following values in a table:
             |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
             |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
-	          |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        | 
+            |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        | 
 
   Scenario: C.3.30.1100.0300. Record's randomized value matches allocation table.  
     # This feature test is REDUNDANT and can be viewed in C.3.30.0200 and C.3.30.0300

--- a/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
@@ -67,7 +67,7 @@ Scenario: #C.3.30.1600.0200 ensures that access is granted when the user has the
     Then I should see a table header and rows containing the following values in a table:
             |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
             |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
-	        |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        | 
+            |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        | 
 
 Scenario: #C.3.30.1600.0100 ensures that access is denied when the user lacks the appropriate permission.
     Given I login to REDCap with the user "Test_User2"

--- a/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
@@ -23,7 +23,10 @@ Scenario: #SETUP project with randomization enabled
     And I uncheck the checkbox labeled "Dashboard"
     And I click on the button labeled "Add user"
     Then I should see 'User "Test_User2" was successfully added'
-    
+    And I should see a table header and rows containing the following values in a table:
+            | Role name               | Username            | Randomization |
+            | —                       | test_user2          | Setup Randomize |
+
     #SETUP Creating randomiztion stategy and adding allocation table.
     When I click on the link labeled "Setup"
     And I click on the button labeled "Set up randomization"
@@ -55,13 +58,16 @@ Scenario: #SETUP project with randomization enabled
     Then I should see "Record ID 2 successfully edited."
 
 Scenario: #C.3.30.1600.0200 ensures that access is granted when the user has the correct dashboard rights. 
-    When I click on the link labeled "Setup"
+    Given I login to REDCap with the user "Test_User1"
+    And I click on the link labeled "My Projects"
+    And I click on the link labeled "C.3.30.1600."
+    And I click on the link labeled "Setup"
     And I click on the button labeled "Set up randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     Then I should see a table header and rows containing the following values in a table:
             |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
             |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
-	          |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        | 
+	        |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        | 
 
 Scenario: #C.3.30.1600.0100 ensures that access is denied when the user lacks the appropriate permission.
     Given I login to REDCap with the user "Test_User2"
@@ -72,7 +78,7 @@ Scenario: #C.3.30.1600.0100 ensures that access is denied when the user lacks th
     Then I should see a table header and rows containing the following values in a table:
             | #      | Target     | Allocation Type | Stratification | Total Allocation (Development) |Total Allocation (Production)| Setup | Randomization ID |
             | 1      | rand_group |                 | strat_1        | 2                              | 0                           |       | 2                |
-
+    
     And I should NOT see a button labeled "Dashboard"
 
     #Given I logout


### PR DESCRIPTION
This PR is meant to address the issues documented in https://github.com/vanderbilt-redcap/redcap_rsvc/pull/315#discussion_r2240734483

**Updates include adding steps to account for:**

1. Scenario: C.3.30.1100.0200 – User with randomize rights can randomize record
Verify that the "Randomization group" field is populated with an expected value (i.e., what was selected from the allocation table).
Add an assertion confirming that the group assigned matches the stratification input, since that’s the business logic being exercised.

2. C.3.30.1600 – Randomization Dashboard UI Access
Scenario: SETUP project with randomization enabled
It does not explicitly confirm that the Dashboard checkbox is unchecked for Test_User2 by inspecting rights later. Adding a check like:
Then I should NOT see the checkbox labeled "Dashboard" checked in the rights summary for "Test_User2"

3. C.3.30.1600 – Scenario 0200
Please add an explicit login step for Test_User1 at the start of this scenario to ensure the test is properly scoped and isolated.