### PR TITLE
Adding test C.2.19.1400 which is redundent.

### DIFF
--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.1400. - REDUNDANT.record_locking_external_storage.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.1400. - REDUNDANT.record_locking_external_storage.feature
@@ -1,0 +1,7 @@
+Feature: C.2.19.1400. User Interface: The system shall provide a project-level option to enable the Record Locking PDF enhancement for external storage
+    As a REDCap end user
+        I want to verify project-level, and UI behavior for PDF enhancement for external storage
+        So that REDCap correctly supports Part 11 compliance across sessions and file destinations
+
+    Scenario: C.2.19.1400. User Interface: The system shall provide a project-level option to enable the Record Locking PDF enhancement for external storage
+        #REDUNDANT - This test is redundant because Scenario: A.2.19.1000.0100. Disable Security & Authentication Configuration – Password only requires this project level option to be turned on.


### PR DESCRIPTION
This PR is intended to add C.2.19.1400 to our testing process. Since this test is redundant that was documented in the test itself. 

#REDUNDANT - This test is redundant because Scenario: A.2.19.1000.0100. Disable Security & Authentication Configuration – Password only requires this project level option to be turned on.
