### PR TITLE
Remove _NewManual suffixes that I don't believe were intended to be c…

### DIFF
--- a/Feature Tests/A/eDoc_28/A.3.28.1200. - File Upload  w Pin.feature
+++ b/Feature Tests/A/eDoc_28/A.3.28.1200. - File Upload  w Pin.feature
@@ -10,7 +10,7 @@ Feature: A.3.28.1200. Control Center: The system shall support Record-level Lock
     Then if running via automation, start external storage services
 
   Scenario: Setup in control center - admin only
-#FUNCTIONAL_REQUIREMENT A.2.19.1000._NewManual 
+#FUNCTIONAL_REQUIREMENT A.2.19.1000. 
 ###ACTION: Setup in control center - admin only 
     Given I login to REDCap with the user "Test_Admin"
     When I click on the link labeled "Control Center"
@@ -20,7 +20,7 @@ Feature: A.3.28.1200. Control Center: The system shall support Record-level Lock
     And I select "Enable" on the dropdown field labeled "Allow users to e-sign using their Two-Factor Authentication 6-digit PIN in place of their password."
     And I click on the button labeled "Save Changes"
     Then I should see "Your system configuration values have now been changed!"
-#FUNCTIONAL_REQUIREMENT A.3.28.1100._NewManual 
+#FUNCTIONAL_REQUIREMENT A.3.28.1100. 
 #M this script assumes File Storage Methods is configured (File storage is needed for base REDCap file Storage) 
 
   Scenario: ##ACTION: Configure the File Storage
@@ -35,7 +35,7 @@ Feature: A.3.28.1200. Control Center: The system shall support Record-level Lock
     And I enter "mycontainer" into the input field labeled "Azure storage blob container"
     And I click on the button labeled "Save Changes"
     And I should see "Your system configuration values have now been changed"
-#FUNCTIONAL_REQUIREMENT  C.2.19.1300._NewManual 
+#FUNCTIONAL_REQUIREMENT  C.2.19.1300. 
 #File Vault Storage is required for Part 11 Compliance 
 
   Scenario: ##ACTION: Configure the File Vault for Record-level Locking Enhancement: PDF confirmation & automatic external file storage
@@ -86,7 +86,7 @@ Feature: A.3.28.1200. Control Center: The system shall support Record-level Lock
     And I click on the button labeled "Save"
     Then I should see "Instrument locked by test_admin"
 
-  Scenario: ##ACTION: Lock entire record C.2.19.1400._NewManual
+  Scenario: ##ACTION: Lock entire record C.2.19.1400.
     When I click on the link labeled "Record Status Dashboard"
     And I click on the link labeled "1"
     When I click on the button labeled "Choose action for record"
@@ -113,7 +113,7 @@ Feature: A.3.28.1200. Control Center: The system shall support Record-level Lock
       | Record ID 1 |
       | Please complete the survey below |
 
-#FUNCTIONAL_REQUIREMENT A.2.19.1100._NewManual 
+#FUNCTIONAL_REQUIREMENT A.2.19.1100. 
 
   Scenario: ###ACTION: Setup in control center - admin only
     When I click on the link labeled "Control Center"
@@ -123,7 +123,7 @@ Feature: A.3.28.1200. Control Center: The system shall support Record-level Lock
     And I click on the button labeled "Save Changes"
     Then I should see "Your system configuration values have now been changed!"
 
-  Scenario: ##ACTION: Lock entire record Record 2 confirms that PIN is not usedC.2.19.1400._NewManual
+  Scenario: ##ACTION: Lock entire record Record 2 confirms that PIN is not usedC.2.19.1400.
     Then I click on the link labeled "My Projects"
     Then I click on the link labeled "A.3.28.1200"
     And I click on the link labeled "Record Status Dashboard"

--- a/Feature Tests/A/eDoc_28/A.3.28.1300. - PDF external storage.feature
+++ b/Feature Tests/A/eDoc_28/A.3.28.1300. - PDF external storage.feature
@@ -4,7 +4,7 @@ Feature: A.3.28.1300 Control Center: The system shall support e-Consent framewor
 #M This is being tested as a full part 11 test so that REDCap Admins learn how to use part 11 features 
 #M The test requires several things to be setup. First in Security and Authentication ensure that you enable "Allow users to e-sign using their Two-Factor Authentication 6-digit PIN in place of their password." Also, The regular File Upload Storage is configure (eDocs) Then finally Configure the File Vault for Record Level Locking Enhancement in the Modules/Services Configuration. User will need access to lock records and E-Sign. 
 #Later in the test, we enable When e-signing, allow users to provide their 6-digit PIN only once per session. (Requires the immediate setting above to be enabled.) 
-#FUNCTIONAL_REQUIREMENT A.3.28.1300._NewManual 
+#FUNCTIONAL_REQUIREMENT A.3.28.1300. 
 
   Scenario: Start external storage services
     # Start these right away to give them plenty of time to spin up before we need them
@@ -18,7 +18,7 @@ Feature: A.3.28.1300 Control Center: The system shall support e-Consent framewor
     And I select "Enable" on the dropdown field labeled "Allow users to e-sign using their Two-Factor Authentication 6-digit PIN in place of their password."
     And I click on the button labeled "Save Changes"
     Then I should see "Your system configuration values have now been changed!"
-#FUNCTIONAL_REQUIREMENT A.3.28.1100._NewManual 
+#FUNCTIONAL_REQUIREMENT A.3.28.1100. 
 #M this script assumes File Storage Methods is configured (File storage is needed for base REDCap file Storage) 
 
   Scenario: ##ACTION: Configure the External File Storage


### PR DESCRIPTION
@4bbakers, I was searching our codebases for reference to NewManual recrod exceptions in order to better support that convention long term.  This PR removes a few `_NewManual` feature number suffixes that I don't think were intended to be committed and kept long term.  Don't hesitate to ask if you have any questions/concerns.