### PR TITLE
Modified Randomization scripts

### DIFF
--- a/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0200. - Randomization project enable.feature
@@ -2,10 +2,10 @@ Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling R
   As a REDCap end user I want to see that Randomization is functioning as expected
 
   Scenario: #SETUP project
-     #SETUP project with no randomization enabled
+    #SETUP project with no randomization enabled
     Given I login to REDCap with the user "Test_User1"
     And I create a new project named "C.3.30.0200." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button
-     #SETUP User Rights
+    #SETUP User Rights
     When I click on the link labeled "User Rights"
     And I click on the link labeled "Test User1"
     And I click on the button labeled "Assign to role"
@@ -16,33 +16,22 @@ Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling R
   Scenario: C.3.30.0200.0100. Enabling adds randomization module to project setup.
     When I click on the link labeled "Setup"
     And I click on the button labeled "Enable" in the row labeled "Randomization module"
-     ##VERIFY Enabling adds randomization module to project setup.
+    ##VERIFY Enabling adds randomization module to project setup.
     And I should see a button labeled "Disable" in the row labeled "Randomization module"
     And I should see "Set up a randomization model"
 
-     #VERIFY _log Enabling adds randomization module to project setup.
+    #VERIFY _log Enabling adds randomization module to project setup.
     When I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
       | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
       | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Modify project settings                 |
 
-  Scenario: C.3.30.0200.0200. Enabling adds randomization module to application box
-    When I click on the link labeled "Setup"
-    Then I should see a button labeled "Set up randomization"
-
-     #VERIFY Enabling adds randomization module to application box
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-      | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
-      | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Modify project settings                 |
+  #Scenario: C.3.30.0200.0200. Enabling adds randomization module to application box
+  #Verified in C.3.30.0200.0100.
 
   Scenario: C.3.30.0200.0300. Enabling adds randomization module options Setup, Dashboard, and Randomize to user rights privilege setup page.
     When I click on the link labeled "User Rights"
-    And I click on the link labeled "Test User1" 
-    And I click on the button labeled "Remove from role"
-    And I click on the button labeled "Close"
-    And I click on the link labeled "Test User1" 
-    And I click on the button labeled "Edit user privileges"
+    And I click on the link labeled "1_FullRights"
     Then I should see "Randomization"
     And I should see "Setup"
     And I should see "Dashboard"
@@ -53,25 +42,22 @@ Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling R
     When I click on the link labeled "Setup"
     Then I should see a button labeled "Disable" in the row labeled "Randomization module"
     When I click on the button labeled "Disable" in the row labeled "Randomization module"
-     #VERIFY Disabling removes randomization module from project setup
+    #VERIFY Disabling removes randomization module from project setup
     Then I should see a button labeled "Enable" in the row labeled "Randomization module"
-    And I should NOT see "Set up a randomization model" 
+    And I should NOT see "Set up a randomization model"
+    And I should NOT see a link labeled "Randomization"
     When I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
       | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
       | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Modify project settings                 |
 
-  Scenario: C.3.30.0200.0500. Disabling removes randomization module from application box.
-    When I click on the link labeled "Setup"
-    Then I should see a button labeled "Enable" in the row labeled "Randomization module"
-     #VERIFY Disabling removes randomization module from application box.
-    And I should NOT see a link labeled "Randomization"
-    And I should NOT see "Set up a randomization model"
+  #Scenario: C.3.30.0200.0500. Disabling removes randomization module from application box.
+  #Verified in C.3.30.0200.0400.
 
   Scenario: C.3.30.0200.0600. Disabling removes randomization module options Setup, Dashboard, and Randomize to user rights privilege setup page.
     When I click on the link labeled "User Rights"
     And I click on the link labeled "1_FullRights"
-     #VERIFY options Setup, Dashboard, and Randomize NOT in user rights privilege setup page.
+    #VERIFY options Setup, Dashboard, and Randomize NOT in user rights privilege setup page.
     Then I should NOT see "Randomization"
     And I should NOT see a checkbox labeled "Setup"
     And I should NOT see a checkbox labeled "Dashboard"

--- a/Feature Tests/C/Randomization_30/C.3.30.0300. - REDUNDANT.Randomization rights setup.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0300. - REDUNDANT.Randomization rights setup.feature
@@ -1,7 +1,0 @@
-Feature: C.3.30.0300 	User Interface: The system shall allow user rights configuration to create and manage Randomization Setup.
-As a REDCap end user
-I want to see that Randomization is functioning as expected
-
-#This feature test is REDUNDANT and can be viewed in Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling Randomization at the project level.
-#Scenario: C.3.30.0300.0100. User with Randomization Setup rights can use Randomization Module Setup Configuration page.
-#Scenario: C.3.30.0300.0200. User without Randomization Setup rights cannot use Randomization Module Setup Configuration page.

--- a/Feature Tests/C/Randomization_30/C.3.30.0300. - Randomization rights setup.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0300. - Randomization rights setup.feature
@@ -1,0 +1,42 @@
+Feature: C.3.30.0300 	User Interface: The system shall allow user rights configuration to create and manage Randomization Setup.
+  As a REDCap end user
+  I want to see that Randomization is functioning as expected
+
+  Scenario: #SETUP project with randomization enabled - "Project 3.30 randAM.xml"
+    Given I login to REDCap with the user "Test_User1"
+    And I create a new project named "C.3.30.0500" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
+
+  Scenario: #SETUP Randomization User Rights (Give User all Rand Rights)
+    When I click on the link labeled "User Rights"
+    And I enter "Test_User1" into the input field labeled "Add with custom rights"
+    And I click on the button labeled "Add with custom rights"
+    And I check the checkbox labeled "Setup"
+    And I check the checkbox labeled "Dashboard"
+    And I check the checkbox labeled "Randomize"
+    And I click on the button labeled "Save Changes"
+    Then I should see 'User "Test_User1" was successfully edited' 
+
+  Scenario: C.3.30.0300.0100. User with Randomization Setup rights can use Randomization Module Setup Configuration page.
+    When I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
+    Then I should see "Randomization"
+    And I should see a button labeled "Add new randomization model"
+    When I click on the button labeled "Add new randomization model"
+    And I select "rand_group (Randomization group 1)" on the dropdown field labeled "- select a field -"
+    And I click on the button labeled "Save randomization model"
+    Then I should see "Success! The randomization model has been saved!"
+    
+
+  Scenario: C.3.30.0300.0200. User without Randomization Setup rights cannot use Randomization Module Setup Configuration page.
+    When I click on the link labeled "User Rights"
+    And I click on the link labeled "Test User1"
+    And I click on the button labeled "Edit user privileges"
+    And I uncheck the checkbox labeled "Setup"
+    And I click on the button labeled "Save Changes"
+    Then I should see 'User "test_user1" was successfully edited'
+
+    When I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
+    Then I should see "Randomization"
+    Then I should NOT see a button labeled "Add new randomization model"
+#END

--- a/Feature Tests/C/Randomization_30/C.3.30.0300. - Randomization rights setup.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0300. - Randomization rights setup.feature
@@ -4,7 +4,7 @@ Feature: C.3.30.0300 	User Interface: The system shall allow user rights configu
 
   Scenario: #SETUP project with randomization enabled - "Project 3.30 randAM.xml"
     Given I login to REDCap with the user "Test_User1"
-    And I create a new project named "C.3.30.0500" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
+    And I create a new project named "C.3.30.0300" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
 
   Scenario: #SETUP Randomization User Rights (Give User all Rand Rights)
     When I click on the link labeled "User Rights"

--- a/Feature Tests/C/Randomization_30/C.3.30.0400. - REDUNDANT.Randomization rights dashboard.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0400. - REDUNDANT.Randomization rights dashboard.feature
@@ -2,6 +2,6 @@ Feature: C.3.30.0400. User Interface: The system shall allow user rights configu
 As a REDCap end user
 I want to see that Randomization is functioning as expected
 
-#This feature test is REDUNDANT and can be viewed in Feature: C.3.30.0200 User Interface: The system shall allow enabling/disabling Randomization at the project level.
+#This feature test is REDUNDANT and can be viewed in Feature: C.3.30.1600 User Interface: The system shall ensure users with randomization dashboard rights can view the randomization dashboard.
 #Scenario: C.3.30.0400.0100. User with Randomization Dashboard rights can use Randomization Module Dashboard page. 
 #Scenario: C.3.30.0400.0200. User without Randomization Dashboard rights cannot use Randomization Module Dashboard page.

--- a/Feature Tests/C/Randomization_30/C.3.30.0500. - Randomization rights randomize.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0500. - Randomization rights randomize.feature
@@ -21,7 +21,6 @@ Feature: C.3.30.0500. User Interface: The system shall allow user rights configu
     And I click on the button labeled "Set up randomization"
     Then I should see "Randomization"
 
-    When I click on the link labeled "Randomization"
     And I click on the icon in the column labeled "Setup" and the row labeled "1"
     When I click on the button labeled "Example #1 (basic)"
     Then I should see a downloaded file named "RandomizationAllocationTemplate.csv"
@@ -29,7 +28,7 @@ Feature: C.3.30.0500. User Interface: The system shall allow user rights configu
     Then I should see "Success! The randomization allocation table was created!"
 
   Scenario: C.3.30.0500.0100. User with Randomization Randomize rights can Randomize.
-#FUNCTIONAL_REQUIREMENT C.3.30.0500.100: User with Randomization Randomize rights can Randomize.
+    #FUNCTIONAL_REQUIREMENT C.3.30.0500.100: User with Randomization Randomize rights can Randomize.
     When I click on the link labeled "Add / Edit Records"
     And I click on a button labeled "Add new record"
     And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
@@ -41,13 +40,14 @@ Feature: C.3.30.0500. User Interface: The system shall allow user rights configu
     And I should see "Blinded randomization"
     And I should see "Automatic Randomization"
     And I should see "Randomize"
-##VERIFY User with Randomization Randomize rights can Randomize.
+    ##VERIFY User with Randomization Randomize rights can Randomize.
     When I click on a button labeled "Randomize"
     Then I should see the radio labeled "Do you describe yourself as a man, a woman, or in some other way?" with option "Man" selected
     And I click on the button labeled "Randomize"
     Then I should see a dialog containing the following text: 'Record ID "6" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).' 
     When I click on the button labeled "Close"
     Then I should see the radio labeled "Randomization group 1" with option "Drug A" selected
+    And I should see "Already randomized"
 
   Scenario: #SETUP User Rights (Takeaway User Rand - Setup Rights)
     When I click on the link labeled "User Rights"
@@ -58,13 +58,12 @@ Feature: C.3.30.0500. User Interface: The system shall allow user rights configu
     Then I should see 'User "test_user1" was successfully edited'
 
   Scenario: C.3.30.0500.0200. User without Randomization Randomize rights cannot Randomize.
-#FUNCTIONAL_REQUIREMENT C.3.30.0500.200: User without Randomization Randomize rights cannot Randomize.
+    #FUNCTIONAL_REQUIREMENT C.3.30.0500.200: User without Randomization Randomize rights cannot Randomize.
     When I click on the link labeled "Add / Edit Records"
     And I click on a button labeled "Add new record"
     And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
 
-  ##VERIFY User without Randomization Randomize rights cannot Randomize.
+    ##VERIFY User without Randomization Randomize rights cannot Randomize.
     Then I should see "Randomization group 1"
     And I should NOT see a button labeled "Randomize"
-
 #END

--- a/Feature Tests/C/Randomization_30/C.3.30.0600. - Randomization DAG.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0600. - Randomization DAG.feature
@@ -2,7 +2,7 @@ Feature: User Interface: The system shall restrict users to randomizing records 
   As a REDCap end user
   I want to see that Randomization is functioning as expected
 
- Scenario: #SETUP project with randomization enabled
+  Scenario: #SETUP project with randomization enabled
     Given I login to REDCap with the user "Test_User1"
     And I create a new project named "C.3.30.0600." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
     #Adding user rights Test_User1
@@ -20,11 +20,18 @@ Feature: User Interface: The system shall restrict users to randomizing records 
     And I click on the button labeled "Add user"
     Then I should see 'User "Test_User2" was successfully added'
   
-    #Adding DAG
+    #Adding DAG 1
     When I click on the link labeled "DAGs"
     Then I should see "Create new groups"
     When I enter "DAG 1" into the field with the placeholder text of "Enter new group name"
     And I click on the button labeled "Add Group"
+
+    #Adding DAG 2
+    When I click on the link labeled "DAGs"
+    Then I should see "Create new groups"
+    When I enter "DAG 2" into the field with the placeholder text of "Enter new group name"
+    And I click on the button labeled "Add Group"
+
     #Assign User to DAG
     Given I click on the link labeled "DAGs"
     When I select "test_user2 (Test User2)" on the dropdown field labeled "Assign user"
@@ -49,7 +56,7 @@ Feature: User Interface: The system shall restrict users to randomizing records 
     Then I upload a "csv" format file located at "downloads/RandomizationAllocationTemplate.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
     
     #Adding Allocation table for automation
-    When I upload a "csv" format file located at "import_files/AllocationTblC.3.30.0600.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    When I upload a "csv" format file located at "import_files/AllocationTblC.3.30.0600.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
     Then I should see " Success! The randomization allocation table was created!"
 
 
@@ -77,21 +84,25 @@ Feature: User Interface: The system shall restrict users to randomizing records 
     Then I should see "Record ID 1-1 successfully edited."
     #M This number may be diferent with manual testing.
 
-      #VERIFY Randomization value was saved and field now has a value.
+    #VERIFY Randomization value was saved and field now has a value.
     When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    Then I should see "Already randomized" 
+    Then I should see "Already randomized"
+    And I should see the radio labeled "Randomization group 2" with option "Drug A" selected
+    And I should see a radio labeled "Drug A" in the row labeled "Randomization group 2" that is disabled
+    And I should see a radio labeled "Drug B" in the row labeled "Randomization group 2" that is disabled
+    And I should see a radio labeled "Placebo" in the row labeled "Randomization group 2" that is disabled
 
-      #VERIFY access restriction | Test_User2 doesn't have access to records outside of their dag.
+    #VERIFY access restriction | Test_User2 doesn't have access to records outside of their dag.
     When I click on the link labeled "Record Status Dashboard"
     Then I should see a table header and rows containing the following values in the record status dashboard table:
       | Record ID |
       | 1-1       |
-      #M This record ID may be diferent with manual testing.
+    #M This record ID may be diferent with manual testing.
 
-      #Verification that user does not have access to record 2. Ensuring they cannot view or randomize records outside their group is fully covered by B.2.10.0400. User Interface: The system shall provide the ability to restrict a user who has been assigned to a DAG.
+    #Verification that user does not have access to record 2. Ensuring they cannot view or randomize records outside their group is fully covered by B.2.10.0400. User Interface: The system shall provide the ability to restrict a user who has been assigned to a DAG.
     And I should see "ALL (1)" 
     
-      #VERIFY Record Randomization was added to the randomization dashboard.
+    #VERIFY Record Randomized was added to the randomization dashboard.
     Given I logout
     And I login to REDCap with the user "Test_User1"
     When I click on the link labeled "My Projects"
@@ -100,20 +111,25 @@ Feature: User Interface: The system shall restrict users to randomizing records 
     And I click on the button labeled "Set up randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     Then I should see a table header and rows containing the following values in a table:
-                 | Used    | Not Used | Allocated records   | Data Access Group  redcap_data_access_group|Randomization group 2  rand_group_2|
-                 | 1       |     0    |     1-1             | DAG 1 (1)                                  | Drug A (1)        | 
-      #M This record ID may be diferent with manual testing.
-       	
-      #VERIFY_log Randomization at project level enabled recorded in logging table
+      | Used    | Not Used | Allocated records   | Data Access Group  redcap_data_access_group|Randomization group 2  rand_group_2|
+      | 0       |     1    |                     | DAG 1 (1)                                  | Drug B (2)                        |
+      | 0       |     1    |                     | DAG 1 (1)                                  | Placebo (3)                       |
+      | 0       |     0    |                     | DAG 2 (2)                                  | Drug A (1)                        |
+      | 0       |     1    |                     | DAG 2 (2)                                  | Drug B (2)                        |
+      | 0       |     1    |                     | DAG 2 (2)                                  | Placebo (3)                       |
+      | 1       |     0    |     1-1             | DAG 1 (1)                                  | Drug A (1)                        |
+    #M This record ID may be diferent with manual testing.
+
+    #VERIFY_log Randomization at project level enabled recorded in logging table
     When I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action              | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user2 | Randomize Record 1-1|Randomize record|
-            | mm/dd/yyyy hh:mm | test_user2 | Update record 1-1   |Assign record to Data Access Group (redcap_data_access_group = 'dag_1')|
-            | mm/dd/yyyy hh:mm | test_user2 | Create record 1-1   |strat_1 = '1', demographics_complete = '0', record_id = '1-1'|
-      #M These record IDs may be diferent with manual testing.
+      | Time / Date      | Username   | Action              | List of Data Changes OR Fields Exported           |
+      | mm/dd/yyyy hh:mm | test_user2 | Randomize Record 1-1| Randomize record |
+      | mm/dd/yyyy hh:mm | test_user2 | Update record 1-1   | Assign record to Data Access Group (redcap_data_access_group = 'dag_1') |
+      | mm/dd/yyyy hh:mm | test_user2 | Create record 1-1   | strat_1 = '1', demographics_complete = '0', record_id = '1-1' |
+    #M These record IDs may be diferent with manual testing.
 
-  
+
   Scenario: FUNCTIONAL_REQUIREMENT C.3.30.0600.0200: The randomization model shall support stratification by DAG, allowing independent randomization assignments within each DAG.
     When I click on the link labeled "Add / Edit Records"
     And I click on the button labeled "Add new record"
@@ -124,18 +140,55 @@ Feature: User Interface: The system shall restrict users to randomizing records 
     And I click on the button labeled "Randomize"
     Then I should see "was randomized for"
     And I click on the button labeled "Close"
-    And I should see "Already randomized" 
+    And I should see "Already randomized"
+    And I should see the radio labeled "Randomization group 2" with option "Drug B" selected
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 6 successfully edited."
 
-      #VERIFY Logging
+    #VERIFY Logging
     When I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
-           |Time / Date        | Username   | Action              | List of Data Changes OR Fields Exported      |
-           | mm/dd/yyyy hh:mm  | test_user1 | Update record 6     |  |
-           | mm/dd/yyyy hh:mm  | test_user1 | Randomize Record 6  | Randomize record  |
-           | mm/dd/yyyy hh:mm  | test_user1 | Update record 6     | Assign record to Data Access Group (redcap_data_access_group = 'dag_1') |
-           | mm/dd/yyyy hh:mm  | test_user1 | Create record 6     | record_id = '6', rand_group_2 = '2', randomization_complete = '0' |
+      |Time / Date        | Username   | Action              | List of Data Changes OR Fields Exported      |
+      | mm/dd/yyyy hh:mm  | test_user1 | Update record 6     |  |
+      | mm/dd/yyyy hh:mm  | test_user1 | Randomize Record 6  | Randomize record  |
+      | mm/dd/yyyy hh:mm  | test_user1 | Update record 6     | Assign record to Data Access Group (redcap_data_access_group = 'dag_1') |
+      | mm/dd/yyyy hh:mm  | test_user1 | Create record 6     | record_id = '6', rand_group_2 = '2', randomization_complete = '0' |
 
-And I logout
+
+  Scenario: FUNCTIONAL_REQUIREMENT C.3.30.0600.0200: The randomization model shall support stratification by DAG, allowing independent randomization assignments within each DAG.
+    When I click on the link labeled "Add / Edit Records"
+    And I click on the button labeled "Add new record"
+    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+    And I click on the button labeled "Randomize"
+    Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
+    When I select "DAG 2" on the dropdown field labeled "Assign this record to a Data Access Group"
+    And I click on the button labeled "Randomize"
+    Then I should see "was randomized for"
+    And I click on the button labeled "Close"
+    And I should see "Already randomized"
+    And I should see the radio labeled "Randomization group 2" with option "Drug A" selected
+    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+    Then I should see "Record ID 7 successfully edited."
+
+    #VERIFY Logging
+    When I click on the link labeled "Logging"
+    Then I should see a table header and rows containing the following values in the logging table:
+      |Time / Date        | Username   | Action              | List of Data Changes OR Fields Exported      |
+      | mm/dd/yyyy hh:mm  | test_user1 | Update record 7     |  |
+      | mm/dd/yyyy hh:mm  | test_user1 | Randomize Record 7  | Randomize record  |
+      | mm/dd/yyyy hh:mm  | test_user1 | Update record 7     | Assign record to Data Access Group (redcap_data_access_group = 'dag_2') |
+      | mm/dd/yyyy hh:mm  | test_user1 | Create record 7     | record_id = '7', rand_group_2 = '1', randomization_complete = '0' |
+
+    When I click on the link labeled "Randomization"
+    And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
+    Then I should see a table header and rows containing the following values in a table:
+      | Used    | Not Used | Allocated records   | Data Access Group  redcap_data_access_group|Randomization group 2  rand_group_2|
+      | 0       |     1    |                     | DAG 1 (1)                                  | Placebo (3)        |
+      | 0       |     1    |                     | DAG 2 (2)                                  | Drug B (2)         |
+      | 0       |     1    |                     | DAG 2 (2)                                  | Placebo (3)        |
+      | 1       |     0    |     1-1             | DAG 1 (1)                                  | Drug A (1)         |
+      | 1       |     0    |     6               | DAG 1 (1)                                  | Drug B (2)         |
+      | 1       |     0    |     7               | DAG 2 (2)                                  | Drug A (1)         |
+      #M This record ID may be diferent with manual testing.
+    And I logout
 #END

--- a/Feature Tests/C/Randomization_30/C.3.30.0600. - Randomization DAG.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0600. - Randomization DAG.feature
@@ -61,6 +61,7 @@ Feature: User Interface: The system shall restrict users to randomizing records 
 
 
   Scenario: #FUNCTIONAL_REQUIREMENT C.3.30.0600.0100. Users within a DAG can randomize records only within their assigned DAG, ensuring they cannot view or randomize records outside their group.
+    # Testing DAG 1 works as expected
     Given I logout
     And I login to REDCap with the user "Test_User2"
     When I click on the link labeled "My Projects"
@@ -154,8 +155,7 @@ Feature: User Interface: The system shall restrict users to randomizing records 
       | mm/dd/yyyy hh:mm  | test_user1 | Update record 6     | Assign record to Data Access Group (redcap_data_access_group = 'dag_1') |
       | mm/dd/yyyy hh:mm  | test_user1 | Create record 6     | record_id = '6', rand_group_2 = '2', randomization_complete = '0' |
 
-
-  Scenario: FUNCTIONAL_REQUIREMENT C.3.30.0600.0200: The randomization model shall support stratification by DAG, allowing independent randomization assignments within each DAG.
+    # Testing DAG 2 works as expected
     When I click on the link labeled "Add / Edit Records"
     And I click on the button labeled "Add new record"
     And I click the bubble for the row labeled "Randomization" on the column labeled "Status"

--- a/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
@@ -1,539 +1,466 @@
 Feature: C.3.30.0700 User Interface: The system shall ensure users with Randomization Setup can create and modify randomization models while in project development mode.
-  As a REDCap end user
-  I want to see that Randomization is functioning as expected
-  
-Scenario: #SETUP project with randomization enabled
-    Given I login to REDCap with the user "Test_User1"
-    And I create a new project named "C.3.30.0700." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
-    #Adding user rights Test_User1
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
-    And I click on the button labeled "Assign to role"
-    And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
-    When I click on the button labeled "Assign"
-    Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
-    #Adding user rights Test_Admin
-    When I click on the link labeled "User Rights"
-    And I enter "Test_Admin" into the field with the placeholder text of "Assign new user to role"
-    And I click on the button labeled "Assign to role"
-    And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
-    When I click on the button labeled "Assign"
-    Then I should see "test_admin" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
-    #Adding user Test_User2 (No randomization rights)
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User2" into the field with the placeholder text of "Add new user"
-    And I click on the button labeled "Add with custom rights"
-    And I click on the checkbox labeled "Project Design and Setup"
-    And I click on the button labeled "Add user"
-    Then I should see 'User "Test_User2" was successfully added'
-    #Adding DAG
-    When I click on the link labeled "DAGs"
-    Then I should see "Create new groups"
-    When I enter "DAG 1" into the field with the placeholder text of "Enter new group name"
-    And I click on the button labeled "Add Group"
-   
-    #VERIFY
-    Then I should see a table header and rows containing the following values in a table:
+    As a REDCap end user
+    I want to see that Randomization is functioning as expected
+
+    Scenario: #SETUP project with randomization enabled
+        Given I login to REDCap with the user "Test_User1"
+        And I create a new project named "C.3.30.0700." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
+
+        #Adding user rights Test_User1
+        When I click on the link labeled "User Rights"
+        And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
+        And I click on the button labeled "Assign to role"
+        And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
+        When I click on the button labeled "Assign"
+        Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+
+        #Adding user rights Test_Admin
+        When I click on the link labeled "User Rights"
+        And I enter "Test_Admin" into the field with the placeholder text of "Assign new user to role"
+        And I click on the button labeled "Assign to role"
+        And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
+        When I click on the button labeled "Assign"
+        Then I should see "test_admin" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+
+        #Adding user Test_User2 (No randomization rights)
+        When I click on the link labeled "User Rights"
+        And I enter "Test_User2" into the field with the placeholder text of "Add new user"
+        And I click on the button labeled "Add with custom rights"
+        And I click on the checkbox labeled "Project Design and Setup"
+        And I click on the button labeled "Add user"
+        Then I should see 'User "Test_User2" was successfully added'
+
+        #Adding DAG
+        When I click on the link labeled "DAGs"
+        Then I should see "Create new groups"
+        When I enter "DAG 1" into the field with the placeholder text of "Enter new group name"
+        And I click on the button labeled "Add Group"
+
+        #VERIFY
+        Then I should see a table header and rows containing the following values in a table:
             | Data Access Groups |
-            | DAG 1         |
+            | DAG 1              |
 
+    Scenario: C.3.30.0700.2300. User without Randomization Setup rights cannot access Setup via Project Setup
+        Given I logout
+        And I login to REDCap with the user "Test_User2"
+        And I click on the link labeled "Setup"
+        Then I should see a button labeled "Set up randomization" that is disabled
 
-Scenario: C.3.30.0700.2300. User without Randomization Setup rights cannot access Setup via Project Setup
-    Given I logout
-    And I login to REDCap with the user "Test_User2"
-    When I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.0700."
-    And I click on the link labeled "Setup"
-    Then I should see a button labeled "Set up randomization" that is disabled
-    
-Scenario: C.3.30.0700.2100. Attempt to use non-categorical field for stratification
-    Given I logout
-    And I login to REDCap with the user "Test_User1"
-    And I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.0700."
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "A) Use stratified randomization?"
-    Then I should NOT see "fname" on the dropdown field labeled "- select a field -"
+    Scenario: C.3.30.0700.2100. Attempt to use non-categorical field for stratification
+        Given I logout
+        And I login to REDCap with the user "Test_User1"
+        And I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I check the checkbox labeled "A) Use stratified randomization?"
+        Then I should NOT see "fname" on the dropdown field labeled "- select a field -"
 
-Scenario: C.3.30.0700.0200. Enable stratified randomization with one stratum. 
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "A) Use stratified randomization?"
-    And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-    
-Scenario: C.3.30.0700.2200 Upload invalid allocation table in DEVELOPMENT
-    When I upload a "csv" format file located at "import_files/Invalid_Allocation.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "ERROR: The following errors occurred. Please address them and try again."
+    Scenario: C.3.30.0700.0200. Enable stratified randomization with one stratum. 
+        When I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
+        And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
 
-    #Adding valid allocation table
-    When I click on the button labeled "Return to previous page"
-    When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
+        #VERIFY Randomization model was added to the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should see a table header and rows containing the following values in a table:
+            | # | Target       | Stratification   | Randomization ID |
+            | 2 | rand_group   | strat_1          | 2                |
 
-Scenario: C.3.30.0700.2000. Modify an existing randomization model
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    Then I should see "If you wish to modify the randomization setup below, you will need to click the Erase Randomization Model button below."
+    Scenario: C.3.30.0700.2200 Upload invalid allocation table in DEVELOPMENT
+        When I click on the icon in the column labeled "Setup" and the row labeled "1"
+        And I upload a "csv" format file located at "import_files/Invalid_Allocation.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+        Then I should see "ERROR: The following errors occurred. Please address them and try again."
 
-    # Create Record for one stratum
-    When I click on the link labeled "Add / Edit Records"
-    And I select "1" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
-    And I select the radio option "Yes" for the field labeled "Stratification 1"
-    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-    Then I should see "Record ID 1 successfully edited."
+        #Adding valid allocation table
+        When I click on the button labeled "Return to previous page"
+        When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+        Then I should see "Already uploaded"
 
-    When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    And I click on the button labeled "Randomize" 
-    Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
-    And I click on the button labeled "Randomize"
-    Then I should see "was randomized for"
-    And I click on the button labeled "Close"
-    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-    Then I should see "Record ID 1 successfully edited."
-    
+    Scenario: C.3.30.0700.2000. Modify an existing randomization model
+        Then I should see "If you wish to modify the randomization setup below, you will need to click the Erase Randomization Model button below."
 
-    #VERIFY Randomization model was added to the randomization summary.
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I click on the link labeled "Dashboard"
-    Then I should see a table header and rows containing the following values in a table:
-            |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
-            |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
-	    |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        | 	
-            	
-    #VERIFY_log Randomization at project level enabled recorded in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action            | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Randomize Record 1|Randomize record|
-            | mm/dd/yyyy hh:mm | test_user1 | Update record 1   |rand_group = '1'|
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design     |Upload randomization allocation table - development (rid=2)|
+        # Create Record for one stratum
+        When I click on the link labeled "Add / Edit Records"
+        And I select "1" on the dropdown field labeled "Choose an existing Record ID"
+        And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
+        And I select the radio option "Yes" for the field labeled "Stratification 1"
+        And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+        Then I should see "Record ID 1 successfully edited."
 
-Scenario: C.3.30.0700.0100. Disable stratified randomization.  
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "A) Use stratified randomization?"
-    And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I uncheck the checkbox labeled "A) Use stratified randomization?"
-    Then I should NOT see "Choose strata"
+        When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+        And I click on the button labeled "Randomize" 
+        Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
+        And I click on the button labeled "Randomize"
+        Then I should see "was randomized for"
+        And I click on the button labeled "Close"
+        And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+        Then I should see "Record ID 1 successfully edited."
 
-Scenario: C.3.30.0700.1100. Erase randomization model. 
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I wait for 1 second
-    And I click on the button labeled "Erase randomization model"
-    And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-    Then I should see "Add new randomization model"
+        #VERIFY Randomization model was added to the randomization summary.
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1"
+        And I click on the link labeled "Dashboard"
+        Then I should see a table header and rows containing the following values in a table:
+            | Used    | Not Used | Allocated records | Stratification 1 | Randomization group |
+            | 0       |     1    |                   | No (0)           | Drug B (2)          |
+            | 1       |     0    |     1             | Yes (1)          | Drug A (1)          |
 
-    #VERIFY_log Randomization at project level enabled recorded in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
+        #VERIFY_log Randomization at project level enabled recorded in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action            | List of Data Changes OR Fields Exported |
+            | mm/dd/yyyy hh:mm | test_user1 | Randomize Record 1| Randomize record                        |
+            | mm/dd/yyyy hh:mm | test_user1 | Update record 1   | rand_group = '1'                        |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design     | Upload randomization allocation table - development (rid=2) |
+
+    Scenario: C.3.30.0700.0100. Disable stratified randomization.  
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I check the checkbox labeled "A) Use stratified randomization?"
+        Then I should see "Choose strata"
+        When I uncheck the checkbox labeled "A) Use stratified randomization?"
+        Then I should NOT see "Choose strata"
+
+    Scenario: C.3.30.0700.1100. Erase randomization model. 
+        Given I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1"
+        And I wait for 1 second
+        And I click on the button labeled "Erase randomization model"
+        And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
+        Then I should see "Add new randomization model"
+
+        #VERIFY Randomization model was deleted from the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should NOT see "rand_group"
+
+        #VERIFY_log Randomization at project level enabled recorded in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
             | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Erase randomization model and allocations (rid=2)| 
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Erase randomization model and allocations (rid=2) |
 
-Scenario: C.3.30.0700.0300. Enable stratified randomization with up to 14 strata (test all 14). 
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "A) Use stratified randomization?"
-    And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_2 (Stratification 2)" on the second dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_3 (Stratification 3)" on the third dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_4 (Stratification 4)" on the fourth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_5 (Stratification 5)" on the fifth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_6 (Stratification 6)" on the sixth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_7 (Stratification 7)" on the seventh dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_8 (Stratification 8)" on the eighth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_9 (Stratification 9)" on the ninth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_10 (Stratification 10)" on the tenth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_11 (Stratification 11)" on the eleventh dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_12 (Stratification 12)" on the twelfth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_13 (Stratification 13)" on the thirteenth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Add another stratum"
-    And I select "strat_14 (Stratification 14)" on the fourteenth dropdown field labeled "- select a field -"
-    And I select "rand_group (Randomization group 1)" on the fifteenth dropdown field labeled "- select a field -"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-   	
-    #VERIFY_log Randomization at project level enabled recorded in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action            | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design     |Save randomization model (rid=3)|
+    Scenario: C.3.30.0700.0300. Enable stratified randomization with up to 14 strata (test all 14). 
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I check the checkbox labeled "A) Use stratified randomization?"
+        And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_2 (Stratification 2)" on the second dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_3 (Stratification 3)" on the third dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_4 (Stratification 4)" on the fourth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_5 (Stratification 5)" on the fifth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_6 (Stratification 6)" on the sixth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_7 (Stratification 7)" on the seventh dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_8 (Stratification 8)" on the eighth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_9 (Stratification 9)" on the ninth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_10 (Stratification 10)" on the tenth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_11 (Stratification 11)" on the eleventh dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_12 (Stratification 12)" on the twelfth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_13 (Stratification 13)" on the thirteenth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Add another stratum"
+        And I select "strat_14 (Stratification 14)" on the fourteenth dropdown field labeled "- select a field -"
+        When I click on the button labeled "Add another stratum"
+        Then I should see an alert box with the following text: "Sorry, but the maximum number of fields that can be used as randomization criteria is 14"
+        And I select "rand_group (Randomization group 1)" on the fifteenth dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
 
-Scenario: C.3.30.0700.0400. Randomize by group/site enabled with no option selected.  
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "B) Randomize by group/site"
-    And I select "rand_group_2 (Randomization group 2)" on the dropdown field labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomization model"
-    Then I should see an alert box with the following text: "Please choose one of the grouping options OR uncheck the Randomize By Group checkbox"
+        When I click on the link labeled "Summary"
+        Then I should see a table header and rows containing the following values in a table:
+            | # | Target     | Stratification | Randomization ID |
+            | 1 | rand_group | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14 | 3 |
 
-    #VERIFY Randomization model was not added to the randomization summary.
-    When I click on the link labeled "Summary"
-    Then I should see a table header and rows containing the following values in a table:
-            | #      | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Dashboard | Randomization ID |
-            | 1      | rand_group |                 | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14         | 0                              | 0                           |       |           | 3                |
-			
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
+        #VERIFY_log Randomization at project level enabled recorded in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action            | List of Data Changes OR Fields Exported |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design     | Save randomization model (rid=3)        |
+
+    Scenario: C.3.30.0700.0400. Randomize by group/site enabled with no option selected.  
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I check the checkbox labeled "B) Randomize by group/site"
+        And I select "rand_group_2 (Randomization group 2)" on the second dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see an alert box with the following text: "Please choose one of the grouping options OR uncheck the Randomize By Group checkbox"
+
+        #VERIFY Randomization model was not added to the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should NOT see "rand_group_2"
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should NOT see "rid=4"
+
+    Scenario: C.3.30.0700.0500. Randomize by group/site enabled with DAG selected.  
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I check the checkbox labeled "B) Randomize by group/site"
+        And I click on the radio labeled "Use Data Access Groups"
+        And I select "rand_group_2 (Randomization group 2)" on the second dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+
+        #VERIFY Randomization model was added to the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should see a table header and rows containing the following values in a table:
+            | # | Target       | Stratification    | Randomization ID |
+            | 1 | rand_group   | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14 | 3 |
+            | 2 | rand_group_2 | Data Access Group |  4                |
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Save randomization model (rid=4)        |
+
+    Scenario: C.3.30.0700.0600. Randomize by group/site enabled with an existing field selected.  
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I check the checkbox labeled "B) Randomize by group/site"
+        And I click on the radio labeled "Use an existing field to designate each group/site"
+        And I select "gender" on the first dropdown field labeled "- select a field -"
+        And I select "rand_group_3 (Randomization group 3)" on the second dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+
+        #VERIFY Randomization model was added to the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should see a table header and rows containing the following values in a table:
+            | # | Target       | Stratification   | Randomization ID |
+            | 1 | rand_group   | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14 | 3 |
+            | 2 | rand_group_2 | Data Access Group | 4               |
+            | 3 | rand_group_3 | gender            | 5               |
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Save randomization model (rid=5)        | 
+
+
+    Scenario: C.3.30.0700.0700. Choose open randomization dropdown field.   
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I select "rand_group_4" on the first dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+
+        #VERIFY Randomization model was added to the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should see a table header and rows containing the following values in a table:
+            | # | Target       | Stratification   | Randomization ID |
+            | 1 | rand_group   | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14| 3 |
+            | 2 | rand_group_2 | Data Access Group | 4                |
+            | 3 | rand_group_3 | gender            | 5                |
+            | 4 | rand_group_4 |                   | 6                |
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Save randomization model (rid=6)         |
+
+    Scenario: C.3.30.0700.0800. Choose open randomization radio field.  
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I select "rand_group_5" on the first dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+
+        #VERIFY Randomization model was added to the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should see a table header and rows containing the following values in a table:
+            | # | Target       | Stratification    | Randomization ID |
+            | 1 | rand_group   | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14 | 3 |
+            | 2 | rand_group_2 | Data Access Group | 4                |
+            | 3 | rand_group_3 |  gender           | 5                |
+            | 4 | rand_group_4 |                   | 6                |
+            | 5 | rand_group_5 |                   | 7                |
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Save randomization model (rid=7)        |
+
+    Scenario: C.3.30.0700.0900. Choose concealed randomization text field.  
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I select "rand_blind" on the first dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+
+        #VERIFY Randomization model was added to the randomization summary.
+        When I click on the link labeled "Summary"
+        Then I should see a table header and rows containing the following values in a table:
+            | # | Target       | Stratification    | Randomization ID |
+            | 1 | rand_group   | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14 | 3 |
+            | 2 | rand_group_2 | Data Access Group | 4               |
+    	    | 3 | rand_group_3 | gender            | 5               |
+    	    | 4 | rand_group_4 |                   | 6               |
+    	    | 5 | rand_group_5 |                   | 7               |
+    	    | 6 | rand_blind   |                   | 8               |
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Save randomization model (rid=8)        |
+
+    Scenario: C.3.30.0700.1000. Save randomization model.
+        #REDUNDANT - Tested in C.3.30.0700.0200 | C.3.30.0700.0300 | C.3.30.0700.0500 | C.3.30.0700.0600 | C.3.30.0700.0700 | C.3.30.0700.0800 | C.3.30.0700.0900 | 
+
+    Scenario: C.3.30.0700.1200. Download example allocation tables (Excel/CSV).
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I select "rand_group_6" on the first dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+        And I should see "STEP 2: Download template allocation tables (as Excel/CSV files)"
+        # Example 1 download
+        When I click on the button labeled "Example #1 (basic)"
+        Then I should see a downloaded file named "RandomizationAllocationTemplate.csv"
+        # Example 2 download
+        When I click on the button labeled "Example #2 (all possible combos)"
+        Then I should see a downloaded file named "RandomizationAllocationTemplate.csv"
+        # Example 3 download
+        When I click on the button labeled "Example #3 (5x all possible combos)"
+        Then I should see a downloaded file named "RandomizationAllocationTemplate.csv"
+
+    Scenario: C.3.30.0700.1300. User with Randomization Setup uploads a unique allocation table in DEVELOPMENT status (system prevents duplicate uploads).
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1" 
+        Then I should see "STEP 3: Upload your allocation table (CSV file)"
+
+        When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+        Then I should see "Already uploaded"
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported                     |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Upload randomization allocation table - development (rid=3) |
+
+    Scenario: C.3.30.0700.1400. User with Randomization Setup downloads the allocation table previously uploaded in DEVELOPMENT.
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1" 
+        Then I should see "STEP 3: Upload your allocation table (CSV file)"
+        When I click on the button labeled "Download table"
+        Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported               |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Download randomization allocation table (development) |
+
+    Scenario: C.3.30.0700.1600. User with Randomization Setup uploads a unique allocation table in PRODUCTION status (system prevents duplicate uploads).
+        #Duplicate Upload File
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1" 
+        Then I should see "STEP 3: Upload your allocation table (CSV file)"
+
+        When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+        Then I should see "ERROR: Duplicate allocation table!"
+
+        #Different Upload File
+        When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate_new.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+        Then I should see "Already uploaded"
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported                    |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Upload randomization allocation table - production (rid=3) |
+
+    Scenario: C.3.30.0700.1700. User with Randomization Setup downloads the allocation table previously uploaded in PRODUCTION.
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1" 
+        Then I should see "STEP 3: Upload your allocation table (CSV file)"
+        When I click on the second button labeled "Download table"
+        Then I should see a downloaded file named "RandomizationAllocationTable_Prod.csv"
+
+        #VERIFY_log Randomization saved in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported               |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Download randomization allocation table (development) |
+
+    Scenario: C.3.30.0700.1500. User with Randomization Setup deletes the allocation table previously uploaded in DEVELOPMENT.
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1" 
+        Then I should see "STEP 3: Upload your allocation table (CSV file)"
+        When I click on the link labeled "Delete allocation table?"
+        Then I should see "Success! The allocation table has been deleted."
+        And I wait for 1 second
+        #VERIFY_log Randomization deleted in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported             |
+            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design | Delete randomization allocation table (development) |
+
+    Scenario: C.3.30.0700.1800. Admin deletes the allocation table previously uploaded in PRODUCTION.
+        Given I logout
+        And I login to REDCap with the user "Test_Admin"
+        And I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1" 
+        Then I should see "STEP 3: Upload your allocation table (CSV file)"
+        When I click on the link labeled "Delete allocation table?"
+        Then I should see "Success! The allocation table has been deleted."
+        And I wait for 1 second
+        #VERIFY_log Randomization deleted in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported            |
+            | mm/dd/yyyy hh:mm | test_admin | Manage/Design | Delete randomization allocation table (production) |
+
+        #Check if below xan be deleted as additional allocation is verified in 900. All beow steps are for that???
+        #Removing randomization models
+        Given I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "rand_group_6"
+        And I wait for 1 second
+        And I click on the button labeled "Erase randomization model"
+        And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
+        Then I should see "Add new randomization model"
+        Then I should NOT see "rand_group_6"
+
+        #VERIFY_log Randomization model deleted in logging table
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
             | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Save randomization model (rid=3)| 
+            | mm/dd/yyyy hh:mm | test_admin | Manage/Design | Erase randomization model and allocations (rid=9) |
 
-Scenario: C.3.30.0700.0500. Randomize by group/site enabled with DAG selected.  
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "B) Randomize by group/site"
-    And I click on the radio labeled "Use Data Access Groups"
-    And I select "rand_group_2 (Randomization group 2)" on the dropdown field labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-
-    #VERIFY Randomization model was added to the randomization summary.
-    When I click on the link labeled "Summary"
-    Then I should see a table header and rows containing the following values in a table:
-            | #     | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Dashboard | Randomization ID |
-            | 1     | rand_group |                 | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14         | 0                              | 0                           |       |           | 3                |
-            | 2     | rand_group_2 |                 | Data Access Group | 0                              | 0                           |       |           | 4                |
-			
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Save randomization model (rid=4)| 
-
-
- Scenario: C.3.30.0700.0600. Randomize by group/site enabled with an existing field selected.  
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "B) Randomize by group/site"
-    And I click on the radio labeled "Use an existing field to designate each group/site"
-    And I select "gender" on the first dropdown field labeled "- select a field -"
-    And I select "rand_group_3 (Randomization group 3)" on the dropdown field labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-
-    #VERIFY Randomization model was added to the randomization summary.
-    When I click on the link labeled "Summary"
-    Then I should see a table header and rows containing the following values in a table:
-            | #      | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Dashboard | Randomization ID |
-            | 1      | rand_group |                 | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14         | 0                              | 0                           |       |           | 3                |
-            | 2      | rand_group_2 |                 | Data Access Group | 0                              | 0                           |       |           | 4                |
-	    | 3      | rand_group_3 |                 | gender | 0                              | 0                           |       |           | 5                |
-			
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Save randomization model (rid=5)| 
-
- Scenario: C.3.30.0700.0700. Choose open randomization dropdown field.   
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I select "rand_group_4" on the first dropdown field labeled "- select a field -"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-
-    #VERIFY Randomization model was added to the randomization summary.
-    When I click on the link labeled "Summary"
-    Then I should see a table header and rows containing the following values in a table:
-            | #      | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Dashboard | Randomization ID |
-            | 1      | rand_group |                 | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14         | 0                              | 0                           |       |           | 3                |
-            | 2      | rand_group_2 |                 | Data Access Group | 0                              | 0                           |       |           | 4                |
-	    | 3      | rand_group_3 |                 | gender | 0                              | 0                           |       |           | 5                |
-	    | 4      | rand_group_4 |                 |                | 0                              | 0                           |       |           | 6               |
-			
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Save randomization model (rid=6)                   |
-
-
- Scenario: C.3.30.0700.0800. Choose open randomization radio field.  
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I select "rand_group_5" on the first dropdown field labeled "- select a field -"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-
-    #VERIFY Randomization model was added to the randomization summary.
-    When I click on the link labeled "Summary"
-    Then I should see a table header and rows containing the following values in a table:
-            | #      | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Dashboard | Randomization ID |
-            | 1      | rand_group |                 | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14         | 0                              | 0                           |       |           | 3                |
-            | 2      | rand_group_2 |                 | Data Access Group | 0                              | 0                           |       |           | 4                |
-	    | 3      | rand_group_3 |                 | gender | 0                              | 0                           |       |           | 5                |
-	    | 4      | rand_group_4 |                 |                | 0                              | 0                           |       |           | 6               |
-	    | 5      | rand_group_5 |                 |        | 0                              | 0                           |       |           | 7               |
-			
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Save randomization model (rid=7)|
-
- Scenario: C.3.30.0700.0900. Choose concealed randomization text field.  
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I select "rand_blind" on the first dropdown field labeled "- select a field -"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-
-    #VERIFY Randomization model was added to the randomization summary.
-    When I click on the link labeled "Summary"
-    Then I should see a table header and rows containing the following values in a table:
-            | #      | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Dashboard | Randomization ID |
-            | 1      | rand_group |                 | strat_1 strat_2 strat_3 strat_4 strat_5 strat_6 strat_7 strat_8 strat_9 strat_10 strat_11 strat_12 strat_13 strat_14         | 0                              | 0                           |       |           | 3                |
-            | 2      | rand_group_2 |                 | Data Access Group | 0                              | 0                           |       |           | 4                |
-	    | 3      | rand_group_3 |                 | gender | 0                              | 0                           |       |           | 5                |
-	    | 4      | rand_group_4 |                 |                | 0                              | 0                           |       |           | 6               |
-	    | 5      | rand_group_5 |                 |        | 0                              | 0                           |       |           | 7               |
-	    | 6      | rand_blind |                 |        | 0                              | 0                           |       |           | 8               |
-	
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Save randomization model (rid=8)|
-
- Scenario: C.3.30.0700.1000. Save randomization model.  
-    #REDUNDANT - Tested in C.3.30.0700.0200 | C.3.30.0700.0300 | C.3.30.0700.0500 | C.3.30.0700.0600 | C.3.30.0700.0700 | C.3.30.0700.0800 | C.3.30.0700.0900 | 
-
- Scenario: C.3.30.0700.1200. Download example allocation tables (Excel/CSV).  
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I select "rand_group_6" on the first dropdown field labeled "- select a field -"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-    And I should see "STEP 2: Download template allocation tables (as Excel/CSV files)"
-    # Example 1 download
-    When I click on the button labeled "Example #1 (basic)"
-    Then I should see a downloaded file named "RandomizationAllocationTemplate.csv"
-    # Example 2 download
-    When I click on the button labeled "Example #2 (all possible combos)"
-    Then I should see a downloaded file named "RandomizationAllocationTemplate.csv"
-    # Example 3 download
-    When I click on the button labeled "Example #3 (5x all possible combos)"
-    Then I should see a downloaded file named "RandomizationAllocationTemplate.csv"
-
- Scenario: C.3.30.0700.1300. User with Randomization Setup uploads a unique allocation table in DEVELOPMENT status (system prevents duplicate uploads).
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-
-    When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
-
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Upload randomization allocation table - development (rid=3)|
-
- Scenario: C.3.30.0700.1400. User with Randomization Setup downloads the allocation table previously uploaded in DEVELOPMENT.
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the button labeled "Download table"
-    Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
-
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
-    
- Scenario: C.3.30.0700.1600. User with Randomization Setup uploads a unique allocation table in PRODUCTION status (system prevents duplicate uploads).
-    #Duplicate Upload File
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-
-    When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "ERROR: Duplicate allocation table!"
-
-    #Different Upload File
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-
-    When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate_new.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
-
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Upload randomization allocation table - production (rid=3)|
-
- Scenario: C.3.30.0700.1700. User with Randomization Setup downloads the allocation table previously uploaded in PRODUCTION.
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the second button labeled "Download table"
-    Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
-
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
-
- Scenario: C.3.30.0700.1500. User with Randomization Setup deletes the allocation table previously uploaded in DEVELOPMENT.
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the link labeled "Delete allocation table?"
-    Then I should see "Success! The allocation table has been deleted."
-    And I wait for 1 second
-    #VERIFY_log Randomization deleted in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Delete randomization allocation table (development)|
-
- Scenario: C.3.30.0700.1800. Admin deletes the allocation table previously uploaded in PRODUCTION.
-    Given I logout
-    And I login to REDCap with the user "Test_Admin"
-    When I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.0700."
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the link labeled "Delete allocation table?"
-    Then I should see "Success! The allocation table has been deleted."
-    And I wait for 1 second
-    #VERIFY_log Randomization deleted in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_admin | Manage/Design |Delete randomization allocation table (production)|
-
-    #Removing randomization models so we can move the project to production and test 
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I wait for 1 second
-    And I click on the button labeled "Erase randomization model"
-    And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-    Then I should see "Add new randomization model"
-
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I wait for 1 second
-    And I click on the button labeled "Erase randomization model"
-    And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-    Then I should see "Add new randomization model"
-
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I wait for 1 second
-    And I click on the button labeled "Erase randomization model"
-    And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-    Then I should see "Add new randomization model"
-    
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I wait for 1 second
-    And I click on the button labeled "Erase randomization model"
-    And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-    Then I should see "Add new randomization model"
-
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I wait for 1 second
-    And I click on the button labeled "Erase randomization model"
-    And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-    Then I should see "Add new randomization model"
-
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I wait for 1 second
-    And I click on the button labeled "Erase randomization model"
-    And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-    Then I should see "Add new randomization model"
-
-  
-    #SETUP_PRODUCTION (Re-adding allocation tables so the project can be moved to production)
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-
-    When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate_1basic.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
-
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-
-    When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate_2allcombos.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
-
-   #SETUP
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Move project to production"
-    And I click on the radio labeled "Keep ALL data saved so far"
-    And I click on the button labeled "YES, Move to Production Status"
-
-    #VERIFY
-    Then I should see "Project status:  Production"
-
- Scenario: C.3.30.0700.1900. Admin uploads an additional allocation table in PRODUCTION status.
-    Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "1"
-    And I click on the link labeled "Upload more allocations?"
-    And I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate_2allcombos2.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Success! New assignments were appended to your existing randomization allocation table!"
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_admin | Manage/Design |Upload randomization allocation table to append - production (rid=9)|
-    
+    #Scenario: C.3.30.0700.1900 - Verified in CC.3.30.0900.0600. Admin can upload additional allocations to existing table in production.
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
@@ -445,22 +445,5 @@ Feature: C.3.30.0700 User Interface: The system shall ensure users with Randomiz
             | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported            |
             | mm/dd/yyyy hh:mm | test_admin | Manage/Design | Delete randomization allocation table (production) |
 
-        #Check if below xan be deleted as additional allocation is verified in 900. All beow steps are for that???
-        #Removing randomization models
-        Given I click on the link labeled "Setup"
-        And I click on the button labeled "Set up randomization"
-        And I click on the icon in the column labeled "Setup" and the row labeled "rand_group_6"
-        And I wait for 1 second
-        And I click on the button labeled "Erase randomization model"
-        And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
-        Then I should see "Add new randomization model"
-        Then I should NOT see "rand_group_6"
-
-        #VERIFY_log Randomization model deleted in logging table
-        When I click on the link labeled "Logging"
-        Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_admin | Manage/Design | Erase randomization model and allocations (rid=9) |
-
-    #Scenario: C.3.30.0700.1900 - Verified in CC.3.30.0900.0600. Admin can upload additional allocations to existing table in production.
+    #Scenario: C.3.30.0700.1900 - Verified in C.3.30.0900.0600. Admin can upload additional allocations to existing table in production.
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
@@ -198,7 +198,7 @@ Feature: C.3.30.0700 User Interface: The system shall ensure users with Randomiz
         And I click on the button labeled "Set up randomization"
         And I click on the button labeled "Add new randomization model"
         And I check the checkbox labeled "B) Randomize by group/site"
-        And I select "rand_group_2 (Randomization group 2)" on the second dropdown field labeled "- select a field -"
+        And I select "rand_group_2 (Randomization group 2)" on the dropdown field labeled "Choose your randomization field"
         And I click on the button labeled "Save randomization model"
         Then I should see an alert box with the following text: "Please choose one of the grouping options OR uncheck the Randomize By Group checkbox"
 
@@ -216,7 +216,7 @@ Feature: C.3.30.0700 User Interface: The system shall ensure users with Randomiz
         And I click on the button labeled "Add new randomization model"
         And I check the checkbox labeled "B) Randomize by group/site"
         And I click on the radio labeled "Use Data Access Groups"
-        And I select "rand_group_2 (Randomization group 2)" on the second dropdown field labeled "- select a field -"
+        And I select "rand_group_2 (Randomization group 2)" on the dropdown field labeled "Choose your randomization field"
         And I click on the button labeled "Save randomization model"
         Then I should see "Success! The randomization model has been saved!"
 
@@ -240,7 +240,7 @@ Feature: C.3.30.0700 User Interface: The system shall ensure users with Randomiz
         And I check the checkbox labeled "B) Randomize by group/site"
         And I click on the radio labeled "Use an existing field to designate each group/site"
         And I select "gender" on the first dropdown field labeled "- select a field -"
-        And I select "rand_group_3 (Randomization group 3)" on the second dropdown field labeled "- select a field -"
+        And I select "rand_group_3 (Randomization group 3)" on the dropdown field labeled "Choose your randomization field"
         And I click on the button labeled "Save randomization model"
         Then I should see "Success! The randomization model has been saved!"
 

--- a/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0700. - Randomization create.feature
@@ -133,6 +133,7 @@ Feature: C.3.30.0700 User Interface: The system shall ensure users with Randomiz
         And I click on the button labeled "Erase randomization model"
         And I should see an alert box with the following text: "Are you sure you wish to erase your randomization setup?"
         Then I should see "Add new randomization model"
+        And I should NOT see "rand_group"
 
         #VERIFY Randomization model was deleted from the randomization summary.
         When I click on the link labeled "Summary"

--- a/Feature Tests/C/Randomization_30/C.3.30.0800. - Randomization automatic.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0800. - Randomization automatic.feature
@@ -2,265 +2,269 @@ Feature: User Interface: The system shall ensure users with Randomization Setup 
   As a REDCap end user
   I want to see that Randomization is functioning as expected
 
-Scenario: #SETUP project with randomization enabled
-Given I login to REDCap with the user "Test_User1"
-And I create a new project named "C.3.30.0800" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "C.3.30 TriggerRand.REDCap.xml", and clicking the "Create Project" button
+  Scenario: #SETUP project with randomization enabled
+    Given I login to REDCap with the user "Test_User1"
+    And I create a new project named "C.3.30.0800" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "C.3.30 TriggerRand.REDCap.xml", and clicking the "Create Project" button
 
-#SETUP User Rights
-Scenario: #SETUP User Rights
-  When I click on the link labeled "User Rights"
-  And I click on the link labeled "Test User1"
-  And I click on the button labeled "Assign to role"
-  And I select "1_FullRights" on the dropdown field labeled "Select Role"
-  And I click on the button labeled "Assign"
-  Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
-  
+  #SETUP User Rights
+  Scenario: #SETUP User Rights
+    When I click on the link labeled "User Rights"
+    And I click on the link labeled "Test User1"
+    And I click on the button labeled "Assign to role"
+    And I select "1_FullRights" on the dropdown field labeled "Select Role"
+    And I click on the button labeled "Assign"
+    Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+
     #Adding user Test_User2 (No randomization rights)
-  When I click on the link labeled "User Rights"
-  And I enter "Test_User2" into the field with the placeholder text of "Assign new user to role"
-  And I click on the button labeled "Assign to role"
-  And I select "5_NoRand" on the dropdown field labeled "Select Role" on the role selector dropdown
-  When I click on the button labeled "Assign"
-  Then I should see "Test User2" within the "5_NoRand" row of the column labeled "Username" of the User Rights table
+    When I click on the link labeled "User Rights"
+    And I enter "Test_User2" into the field with the placeholder text of "Assign new user to role"
+    And I click on the button labeled "Assign to role"
+    And I select "5_NoRand" on the dropdown field labeled "Select Role" on the role selector dropdown
+    When I click on the button labeled "Assign"
+    Then I should see "Test User2" within the "5_NoRand" row of the column labeled "Username" of the User Rights table
 
-  #SETUP randomization for 0100
-  When I click on the link labeled "Project Setup"
-  And I click on the button labeled "Set up randomization"
-  And I click on the button labeled "Add new randomization model"
-  Then I should see "STEP 1: Define your randomization model"
-  And I select "rand_group (Randomization group 1)" on the first dropdown field labeled "- select a field -"
-  And I click on the button labeled "Save randomization model"
-  When I upload a "csv" format file located at "import_files/AlloRand rand_group1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-  When I upload a "csv" format file located at "import_files/AlloRand rand_group2.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    #SETUP randomization for 0100
+    When I click on the link labeled "Project Setup"
+    And I click on the button labeled "Set up randomization"
+    And I click on the button labeled "Add new randomization model"
+    Then I should see "STEP 1: Define your randomization model"
+    And I select "rand_group (Randomization group 1)" on the first dropdown field labeled "- select a field -"
+    And I click on the button labeled "Save randomization model"
+    When I upload a "csv" format file located at "import_files/AlloRand rand_group1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    When I upload a "csv" format file located at "import_files/AlloRand rand_group2.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    And I should see the dropdown field labeled "Trigger option" with the option "Manual only, using Randomize button (default)" selected
 
-Scenario: C.3.30.0800.0100. Manual only, using Randomize button (default)  
-  When I click on the link labeled "Add / Edit Records"
-  And I select "1" on the dropdown field labeled "Choose an existing Record ID"
-  And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-  Then I should see "Randomization group 1"
+  Scenario: C.3.30.0800.0100. Manual only, using Randomize button (default)
+    When I click on the link labeled "Add / Edit Records"
+    And I select "1" on the dropdown field labeled "Choose an existing Record ID"
+    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+    Then I should see "Randomization group 1"
 
-  #VERIFY User can Randomize Manually, using Randomize Button
-  When I click on a button labeled "Randomize"
-  Then I should see a dialog containing the following text: 'Below you may perform randomization for Record ID "1" on the field Randomization group 1 (rand_group).'
-  And I click on the button labeled "Randomize"
-  Then I should see a dialog containing the following text: 'Record ID "1" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).'
-  And I click on the button labeled "Close"
-  And I click on the button labeled "Save & Exit Form"
+    #VERIFY User can Randomize Manually, using Randomize Button
+    When I click on a button labeled "Randomize"
+    Then I should see a dialog containing the following text: 'Below you may perform randomization for Record ID "1" on the field Randomization group 1 (rand_group).'
+    And I click on the button labeled "Randomize"
+    Then I should see a dialog containing the following text: 'Record ID "1" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).'
+    And I click on the button labeled "Close"
+    Then I should see "Already randomized"
+    And I should see the radio labeled "Randomization group 1" with option "Drug A" selected
+    And I click on the button labeled "Save & Exit Form"
 
-  #VERIFY - Logging
-  When I click on the link labeled "Logging"
-  Then I should see a table header and rows containing the following values in the logging table:
-    | Username   | Action             | List of Data Changes OR Fields Exported      |
-    | test_user1 | Update record 1    |                                              |
-    | test_user1 | Randomize Record 1 | Randomize record |
-    | test_user1 | Update record 1  | rand_group = '1' |
+    #VERIFY - Logging
+    When I click on the link labeled "Logging"
+    Then I should see a table header and rows containing the following values in the logging table:
+      | Username   | Action             | List of Data Changes OR Fields Exported      |
+      | test_user1 | Update record 1    |                                              |
+      | test_user1 | Randomize Record 1 | Randomize record |
+      | test_user1 | Update record 1    | rand_group = '1' |
 
-#SETUP Randomization for 0200
-Scenario: C.3.30.0800.0200. Trigger logic, for users with Randomize permissions only  
-  When I click on the link labeled "Setup"
-  And I click on the button labeled "Set up randomization"
-  And I click on the button labeled "Add new randomization model"
-  Then I should see "STEP 1: Define your randomization model"
-  And I select "auto_rand (Automatic Randomization)" on the first dropdown field labeled "- select a field -"
-  And I click on the button labeled "Save randomization model"
-  And I upload a "csv" format file located at "import_files/AlloRand rand_group1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-  And I upload a "csv" format file located at "import_files/AlloRand rand_group2.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-  And I select "Trigger logic, for users with Randomize permission only" on the dropdown field labeled "Trigger option" on the tooltip
+  #SETUP Randomization for 0200
+  Scenario: C.3.30.0800.0200. Trigger logic, for users with Randomize permissions only
+    When I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
+    And I click on the button labeled "Add new randomization model"
+    Then I should see "STEP 1: Define your randomization model"
+    And I select "auto_rand (Automatic Randomization)" on the first dropdown field labeled "- select a field -"
+    And I click on the button labeled "Save randomization model"
+    And I upload a "csv" format file located at "import_files/AlloRand rand_group1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    And I upload a "csv" format file located at "import_files/AlloRand rand_group2.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    And I select "Trigger logic, for users with Randomize permission only" on the dropdown field labeled "Trigger option" on the tooltip
 
-  And I select "Demographics" on the dropdown field labeled "Instrument" on the tooltip
-  And I click on "" in the textarea field labeled "Trigger logic"
-  And I wait for 2 seconds
-  And I enter "[fname]<>'' and [lname]<>''" into the textarea field labeled "Logic Editor"
-  And I click on the button labeled "Update & Close Editor"
-  And I click on the button labeled "Save trigger option"
+    And I select "Demographics" on the dropdown field labeled "Instrument" on the tooltip
+    And I click on "" in the textarea field labeled "Trigger logic"
+    And I wait for 2 seconds
+    And I enter "[fname]<>'' and [lname]<>''" into the textarea field labeled "Logic Editor"
+    And I click on the button labeled "Update & Close Editor"
+    And I click on the button labeled "Save trigger option"
 
-  When I click on the link labeled "Add / Edit Records"
-  And I click on the button labeled "Add new record"
-  And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
-  And I enter "Donald" into the data entry form field labeled "First name" 
-  And I enter "Duck" into the data entry form field labeled "Last name" 
-  And I click on the button labeled "Save & Exit Form"
-  Then I should see "Record ID 6 successfully added." 
+    When I click on the link labeled "Add / Edit Records"
+    And I click on the button labeled "Add new record"
+    And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
+    And I enter "Donald" into the data entry form field labeled "First name"
+    And I enter "Duck" into the data entry form field labeled "Last name"
+    And I click on the button labeled "Save & Exit Form"
+    Then I should see "Record ID 6 successfully added."
 
-  #VERIFY Trigger logic, for users with Randomize permissions only
-  When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-  Then I should see "Already randomized"
-  Then I should see the radio labeled "Automatic Randomization" with option "Group 1" selected
+    #VERIFY Trigger logic, for users with Randomize permissions only
+    When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+    Then I should see "Already randomized"
+    Then I should see the radio labeled "Automatic Randomization" with option "Group 1" selected
 
-  #VERIFY - Logging
-  When I click on the link labeled "Logging"
-  Then I should see a table header and rows containing the following values in the logging table:
-    | Username   | Action             | List of Data Changes OR Fields Exported|
-    | test_user1 | Randomize Record 6 | Randomize record (via trigger)|
-    | test_user1 | Update record 6    | auto_rand = '1'|
-    | test_user1 | Create record 6    | fname = 'Donald', lname = 'Duck', demographics_complete = '0', record_id = '6' |
-    | test_user1 | Manage/Design      | Save randomization execute option (rid = 3) |
+    #VERIFY - Logging
+    When I click on the link labeled "Logging"
+    Then I should see a table header and rows containing the following values in the logging table:
+      | Username   | Action             | List of Data Changes OR Fields Exported|
+      | test_user1 | Randomize Record 6 | Randomize record (via trigger)|
+      | test_user1 | Update record 6    | auto_rand = '1'|
+      | test_user1 | Create record 6    | fname = 'Donald', lname = 'Duck', demographics_complete = '0', record_id = '6' |
+      | test_user1 | Manage/Design      | Save randomization execute option (rid = 3) |
 
-  #SETUP randomization for 0300 and 0400
-  When I click on the link labeled "Setup"
-  And I click on the button labeled "Set up randomization"
-  And I click on the button labeled "Add new randomization model"
-  Then I should see "STEP 1: Define your randomization model"
-  And I select "rand_survey (Go to:)" on the first dropdown field labeled "- select a field -"
-  And I click on the button labeled "Save randomization model"
-  And I upload a "csv" format file located at "import_files/AlloRand rand_group1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-  And I upload a "csv" format file located at "import_files/AlloRand rand_group2.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-  And I select "Trigger logic, for all users (including survey respondents)" on the dropdown field labeled "Trigger option" on the tooltip 
-  And I select "Survey" on the dropdown field labeled "Instrument" on the tooltip
-  And I click on "" in the textarea field labeled "Trigger logic"
-  And I wait for 2 seconds
-  And I enter "[survey_complete]='2'" into the textarea field labeled "Logic Editor"
-  And I click on the button labeled "Update & Close Editor"
-  And I click on the button labeled "Save trigger option"
-  And I click on the link labeled "Home"
-  And I logout
+    #SETUP randomization for 0300 and 0400
+    When I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
+    And I click on the button labeled "Add new randomization model"
+    Then I should see "STEP 1: Define your randomization model"
+    And I select "rand_survey (Go to:)" on the first dropdown field labeled "- select a field -"
+    And I click on the button labeled "Save randomization model"
+    And I upload a "csv" format file located at "import_files/AlloRand rand_group1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    And I upload a "csv" format file located at "import_files/AlloRand rand_group2.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+    And I select "Trigger logic, for all users (including survey respondents)" on the dropdown field labeled "Trigger option" on the tooltip
+    And I select "Survey" on the dropdown field labeled "Instrument" on the tooltip
+    And I click on "" in the textarea field labeled "Trigger logic"
+    And I wait for 2 seconds
+    And I enter "[survey_complete]='2'" into the textarea field labeled "Logic Editor"
+    And I click on the button labeled "Update & Close Editor"
+    And I click on the button labeled "Save trigger option"
+    And I click on the link labeled "Home"
+    And I logout
 
-Scenario: C.3.30.0800.0300 Trigger logic, for all users based on form  
-  Given I login to REDCap with the user "Test_User2"
-  And I click on the link labeled "My Projects"
-  And I click on the link labeled "C.3.30.0800"
-  And I click on the link labeled "Add / Edit Records"
-  And I click on the button labeled "Add new record"
-  And I click the bubble for the row labeled "Survey" on the column labeled "Status"
-  Then I should see "Not yet randomized"
-  And I should see a radio labeled "Survey A" in the row labeled "Not yet randomized" that is disabled
-  And I should see a radio labeled "Survey B" in the row labeled "Not yet randomized" that is disabled
-  And I should see a radio labeled "Survey C" in the row labeled "Not yet randomized" that is disabled
-  And I should see a radio labeled "Survey D" in the row labeled "Not yet randomized" that is disabled
-  And I select the radio option "Yes" for the field labeled "Will you complete the survey?" 
+  Scenario: C.3.30.0800.0300 Trigger logic, for all users based on form
+    Given I login to REDCap with the user "Test_User2"
+    And I click on the link labeled "My Projects"
+    And I click on the link labeled "C.3.30.0800"
+    And I click on the link labeled "Add / Edit Records"
+    And I click on the button labeled "Add new record"
+    And I click the bubble for the row labeled "Survey" on the column labeled "Status"
+    Then I should see "Not yet randomized"
+    And I should see a radio labeled "Survey A" in the row labeled "Not yet randomized" that is disabled
+    And I should see a radio labeled "Survey B" in the row labeled "Not yet randomized" that is disabled
+    And I should see a radio labeled "Survey C" in the row labeled "Not yet randomized" that is disabled
+    And I should see a radio labeled "Survey D" in the row labeled "Not yet randomized" that is disabled
+    And I select the radio option "Yes" for the field labeled "Will you complete the survey?"
 
-  And I select the dropdown option "Complete" for the Data Collection Instrument field labeled "Complete?" 
-  And I select the submit option labeled "Save & Stay" on the Data Collection Instrument
+    And I select the dropdown option "Complete" for the Data Collection Instrument field labeled "Complete?"
+    And I select the submit option labeled "Save & Stay" on the Data Collection Instrument
 
-  #VERIFY Trigger logic, for all users based on form
-  Then I should see "Already randomized"  
-  And I should see the radio labeled "Go to:" with option "Survey A" selected
+    #VERIFY Trigger logic, for all users based on form
+    Then I should see "Already randomized"
+    And I should see the radio labeled "Go to:" with option "Survey A" selected
 
-Scenario: C.3.30.0800.0400 Trigger logic, for all users based on survey  
-  When I click on the link labeled "Add / Edit Records"
-  And I click on the button labeled "Add new record"
-  And I click the bubble for the row labeled "Survey" instrument on the column labeled "Status"
-  Then I should see "Not yet randomized"
-  And I should see a radio labeled "Survey A" in the row labeled "Not yet randomized" that is disabled
-  And I should see a radio labeled "Survey B" in the row labeled "Not yet randomized" that is disabled
-  And I should see a radio labeled "Survey C" in the row labeled "Not yet randomized" that is disabled
-  And I should see a radio labeled "Survey D" in the row labeled "Not yet randomized" that is disabled
-  And I select the radio option "Yes" for the field labeled "Will you complete the survey?"
-  And I select the submit option labeled "Save & Stay" on the Data Collection Instrument
-  And I click on the button labeled "Survey options"
-  And I click on the survey option label containing "Log out+ Open survey" label
-  And I click on the button labeled "Submit"
-  And I click on the button labeled "Close survey"
-  And I return to the REDCap page I opened the survey from
+  Scenario: C.3.30.0800.0400 Trigger logic, for all users based on survey
+    When I click on the link labeled "Add / Edit Records"
+    And I click on the button labeled "Add new record"
+    And I click the bubble for the row labeled "Survey" instrument on the column labeled "Status"
+    Then I should see "Not yet randomized"
+    And I should see a radio labeled "Survey A" in the row labeled "Not yet randomized" that is disabled
+    And I should see a radio labeled "Survey B" in the row labeled "Not yet randomized" that is disabled
+    And I should see a radio labeled "Survey C" in the row labeled "Not yet randomized" that is disabled
+    And I should see a radio labeled "Survey D" in the row labeled "Not yet randomized" that is disabled
+    And I select the radio option "Yes" for the field labeled "Will you complete the survey?"
+    And I select the submit option labeled "Save & Stay" on the Data Collection Instrument
+    And I click on the button labeled "Survey options"
+    And I click on the survey option label containing "Log out+ Open survey" label
+    And I click on the button labeled "Submit"
+    And I click on the button labeled "Close survey"
+    And I return to the REDCap page I opened the survey from
 
-  #VERIFY Trigger Logic, for all users based on survey
-  Given I login to REDCap with the user "Test_User1"
-  And I click on the link labeled "My Projects"
-  And I click on the link labeled "C.3.30.0800"
-  And I click on the link labeled "Add / Edit Records"
-  And I select "8" on the dropdown field labeled "Choose an existing Record ID"
-  And I click the bubble for the row labeled "Survey" instrument on the column labeled "Status" 
-  Then I should see "Already randomized"
-  And I should see the radio labeled "Go to:" with option "Survey B" selected
+    #VERIFY Trigger Logic, for all users based on survey
+    Given I login to REDCap with the user "Test_User1"
+    And I click on the link labeled "My Projects"
+    And I click on the link labeled "C.3.30.0800"
+    And I click on the link labeled "Add / Edit Records"
+    And I select "8" on the dropdown field labeled "Choose an existing Record ID"
+    And I click the bubble for the row labeled "Survey" instrument on the column labeled "Status"
+    Then I should see "Already randomized"
+    And I should see the radio labeled "Go to:" with option "Survey B" selected
 
-  When I click on the link labeled "User Rights"
-  And I enter "Test_Admin" into the field with the placeholder text of "Add new user"
-  And I click on the button labeled "Add with custom rights"
-  And I click on the button labeled "Add user"
-  And I logout
+    When I click on the link labeled "User Rights"
+    And I enter "Test_Admin" into the field with the placeholder text of "Add new user"
+    And I click on the button labeled "Add with custom rights"
+    And I click on the button labeled "Add user"
+    And I logout
 
-  #SETUP move project to production
-  Given I login to REDCap with the user "Test_Admin"
-  And I click on the link labeled "My Projects"
-  And I click on the link labeled "C.3.30.0800"
-  And I click on the button labeled "Move project to production"
-  And I click on the radio labeled "Keep ALL data saved so far"
-  And I click on the button labeled "YES, Move to Production Status"
-  Then I should see an alert box with the following text: "WARNING: RANDOMIZATION FIELD'S DATA WILL BE DELETED"
-  Then I should see "Project status:  Production"
-  And I logout
-  
+    #SETUP move project to production
+    Given I login to REDCap with the user "Test_Admin"
+    And I click on the link labeled "My Projects"
+    And I click on the link labeled "C.3.30.0800"
+    And I click on the button labeled "Move project to production"
+    And I click on the radio labeled "Keep ALL data saved so far"
+    And I click on the button labeled "YES, Move to Production Status"
+    Then I should see an alert box with the following text: "WARNING: RANDOMIZATION FIELD'S DATA WILL BE DELETED"
+    Then I should see "Project status:  Production"
+    And I logout
 
-   #VERIFY - Logging
-  Given I login to REDCap with the user "Test_User1"
-  And I click on the link labeled "My Projects"
-  And I click on the link labeled "C.3.30.0800"
-  When I click on the link labeled "Logging"
-  Then I should see a table header and rows containing the following values in the logging table:
-    | Time / Date      | Username            | Action             | List of Data Changes OR Fields Exported |
-    | mm/dd/yyyy hh:mm | [survey respondent] | Randomize Record 8 | Randomize record (via trigger) |
-    | mm/dd/yyyy hh:mm | [survey respondent] | Update Response 8  | rand_survey = '2' |
-    | mm/dd/yyyy hh:mm | [survey respondent] | Update Response 8  | survey_complete = '2' |
-    | mm/dd/yyyy hh:mm | test_user2          | Create record 8    | will_survey = '1', survey_complete = '0', record_id = '8' |
-    | mm/dd/yyyy hh:mm | test_user2          | Randomize Record 7 | Randomize record (via trigger) |
-    | mm/dd/yyyy hh:mm | test_user2          | Update record 7    | rand_survey = '1' |
-    | mm/dd/yyyy hh:mm | test_user2          | Create record 7    | survey_complete = '2', record_id = '7' |
-    | mm/dd/yyyy hh:mm | test_user1          | Manage/Design      | Save randomization execute option (rid = 4) |
 
-Scenario: C.3.30.0800.0500 Modify trigger while in production
-  When I click on the link labeled "Setup"
-  And I click on the button labeled "Set up randomization"
-  And I click on the icon in the column labeled "Setup" and the row labeled "rand_survey"
-  And I select "Trigger logic, for users with Randomize permission only" on the dropdown field labeled "Trigger option" on the tooltip
-  And I select "Demographics" on the dropdown field labeled "Instrument" on the tooltip
-  And I click on "" in the textarea field labeled "Trigger logic"
-  And I wait for 2 seconds
-  And I clear field and enter "[demographics_complete]='2'" into the textarea field labeled "Logic Editor"
-  And I click on the button labeled "Update & Close Editor"
-  And I click on the button labeled "Save trigger option"
-  And I logout
+    #VERIFY - Logging
+    Given I login to REDCap with the user "Test_User1"
+    And I click on the link labeled "My Projects"
+    And I click on the link labeled "C.3.30.0800"
+    When I click on the link labeled "Logging"
+    Then I should see a table header and rows containing the following values in the logging table:
+      | Time / Date      | Username            | Action             | List of Data Changes OR Fields Exported |
+      | mm/dd/yyyy hh:mm | [survey respondent] | Randomize Record 8 | Randomize record (via trigger) |
+      | mm/dd/yyyy hh:mm | [survey respondent] | Update Response 8  | rand_survey = '2' |
+      | mm/dd/yyyy hh:mm | [survey respondent] | Update Response 8  | survey_complete = '2' |
+      | mm/dd/yyyy hh:mm | test_user2          | Create record 8    | will_survey = '1', survey_complete = '0', record_id = '8' |
+      | mm/dd/yyyy hh:mm | test_user2          | Randomize Record 7 | Randomize record (via trigger) |
+      | mm/dd/yyyy hh:mm | test_user2          | Update record 7    | rand_survey = '1' |
+      | mm/dd/yyyy hh:mm | test_user2          | Create record 7    | survey_complete = '2', record_id = '7' |
+      | mm/dd/yyyy hh:mm | test_user1          | Manage/Design      | Save randomization execute option (rid = 4) |
 
-  #VERIFY Modify trigger while in production
-  Given I login to REDCap with the user "Test_User2"
-  And I click on the link labeled "My Projects" 
-  And I click on the link labeled "C.3.30.0800"
-  And I click on the link labeled "Add / Edit Records"
-  And I select "7" on the dropdown field labeled "Choose an existing Record ID"
-  And I click the bubble for the row labeled "Survey" on the column labeled "Status"
-  Then I should see the radio labeled "Will you complete the survey?" with option "Yes" selected
-  Then I should see the radio labeled "Go to" with option "Survey A" unselected
-  Then I should see "Not yet randomized"
+  Scenario: C.3.30.0800.0500 Modify trigger while in production
+    When I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
+    And I click on the icon in the column labeled "Setup" and the row labeled "rand_survey"
+    And I select "Trigger logic, for users with Randomize permission only" on the dropdown field labeled "Trigger option" on the tooltip
+    And I select "Demographics" on the dropdown field labeled "Instrument" on the tooltip
+    And I click on "" in the textarea field labeled "Trigger logic"
+    And I wait for 2 seconds
+    And I clear field and enter "[demographics_complete]='2'" into the textarea field labeled "Logic Editor"
+    And I click on the button labeled "Update & Close Editor"
+    And I click on the button labeled "Save trigger option"
+    And I logout
 
-  #VERIFY Test_User2 can no longer randomize this record
-  When I click on the link labeled "Demographics"
-  And I wait for 2 seconds
-  And I select the dropdown option "Complete" for the Data Collection Instrument field labeled "Complete?"
-  And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-  And I should see "The grid below displays the form-by-form progress"
-  And I click the bubble for the row labeled "Survey" on the column labeled "Status"
-  Then I should see "Not yet randomized" in the row labeled "Go to"
-  And I click on the button labeled "Cancel"
-  And I logout 
+    #VERIFY Modify trigger while in production
+    Given I login to REDCap with the user "Test_User2"
+    And I click on the link labeled "My Projects"
+    And I click on the link labeled "C.3.30.0800"
+    And I click on the link labeled "Add / Edit Records"
+    And I select "7" on the dropdown field labeled "Choose an existing Record ID"
+    And I click the bubble for the row labeled "Survey" on the column labeled "Status"
+    Then I should see the radio labeled "Will you complete the survey?" with option "Yes" selected
+    Then I should see the radio labeled "Go to" with option "Survey A" unselected
+    Then I should see "Not yet randomized"
 
-  #VERIFY Test_User1 can randomize this record
-  Given I login to REDCap with the user "Test_User1"
-  And I click on the link labeled "My Projects"
-  And I click on the link labeled "C.3.30.0800"
-  And I click on the link labeled "Add / Edit Records"
-  And I select "7" on the dropdown field labeled "Choose an existing Record ID"
-  And I click the bubble for the row labeled "Survey" on the column labeled "Status"
-  Then I should see a button labeled "Randomize" 
-  And I click on the "Randomize" button for the field labeled "Go to"
-  And I should see "Below you may perform randomization"
-  And I click on the button labeled "Randomize"
-  And I click on the button labeled "Close"
-  And I should see the radio labeled "Go to" with option "Survey C" selected
-  And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+    #VERIFY Test_User2 can no longer randomize this record
+    When I click on the link labeled "Demographics"
+    And I wait for 2 seconds
+    And I select the dropdown option "Complete" for the Data Collection Instrument field labeled "Complete?"
+    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+    And I should see "The grid below displays the form-by-form progress"
+    And I click the bubble for the row labeled "Survey" on the column labeled "Status"
+    Then I should see "Not yet randomized" in the row labeled "Go to"
+    And I should NOT see a button labeled "Randomize"
+    And I click on the button labeled "Cancel"
+    And I logout
 
-  #VERIFY - Logging
-  When I click on the link labeled "Logging"
-  Then I should see a table header and rows containing the following values in the logging table:
-    | Username   | Action        | List of Data Changes OR Fields Exported      |
-    | test_user1 | Update record 7 | survey_complete = '2' |
-    | test_user1 | Randomize Record 7 | Randomize record |
-    | test_user1 | Update record 7 | rand_survey = '3', survey_complete = '0' |
-    | test_user2 | Update record 7  | demographics_complete = '2' |
-    | test_user1 | Manage/Design | Save randomization execute option (rid = 4) |
-    | test_admin | Manage/Design | Move project to Production status |
-    | test_admin | Update record 8 | rand_survey = '' |
-    | test_admin | Update record 7 | rand_survey = '' |
-    | test_admin | Update record 6 | auto_rand = '' |
-    | test_admin | Update record 1 | rand_group = '' |
+    #VERIFY Test_User1 can randomize this record
+    Given I login to REDCap with the user "Test_User1"
+    And I click on the link labeled "My Projects"
+    And I click on the link labeled "C.3.30.0800"
+    And I click on the link labeled "Add / Edit Records"
+    And I select "7" on the dropdown field labeled "Choose an existing Record ID"
+    And I click the bubble for the row labeled "Survey" on the column labeled "Status"
+    Then I should see a button labeled "Randomize"
+    And I click on the "Randomize" button for the field labeled "Go to"
+    And I should see "Below you may perform randomization"
+    And I click on the button labeled "Randomize"
+    And I click on the button labeled "Close"
+    And I should see the radio labeled "Go to" with option "Survey C" selected
+    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
 
-  And I logout
+    #VERIFY - Logging
+    When I click on the link labeled "Logging"
+    Then I should see a table header and rows containing the following values in the logging table:
+      | Username   | Action             | List of Data Changes OR Fields Exported      |
+      | test_user1 | Update record 7    | survey_complete = '2' |
+      | test_user1 | Randomize Record 7 | Randomize record |
+      | test_user1 | Update record 7    | rand_survey = '3', survey_complete = '0' |
+      | test_user2 | Update record 7    | demographics_complete = '2' |
+      | test_user1 | Manage/Design      | Save randomization execute option (rid = 4) |
+      | test_admin | Manage/Design      | Move project to Production status |
+      | test_admin | Update record 8    | rand_survey = '' |
+      | test_admin | Update record 7    | rand_survey = '' |
+      | test_admin | Update record 6    | auto_rand = '' |
+      | test_admin | Update record 1    | rand_group = '' |
+
+    And I logout
 #END

--- a/Feature Tests/C/Randomization_30/C.3.30.0900. - Randomization lock.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0900. - Randomization lock.feature
@@ -1,116 +1,111 @@
 Feature: C.3.30.0900.	User Interface: The system shall ensure users with Randomization Setup rights lock randomization models and allocation table while in production mode.	
-As a REDCap end user
-I want to see that Randomization is functioning as expected
+    As a REDCap end user
+    I want to see that Randomization is functioning as expected
 
-Scenario: #SETUP - Create new project
-Given I login to REDCap with the user "Test_Admin"
-And I create a new project named "C.3.30.0900" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "C.3.30.OneRand.xml", and clicking the "Create Project" button
+    Scenario: #SETUP - Create new project
+        Given I login to REDCap with the user "Test_Admin"
+        And I create a new project named "C.3.30.0900" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "C.3.30.OneRand.xml", and clicking the "Create Project" button
 
-#SETUP randomization 
-When I click on the link labeled "Project Setup"
-And I click on the button labeled "Set up randomization"
-And I click on the icon in the column labeled "Setup" and the row labeled "1"
-And I upload a "csv" format file located at "import_files/AlloRand rand_group3.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
-And I upload a "csv" format file located at "import_files/AlloRand rand_group4.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
-When I click on the link labeled "Setup"
-And I click on the button labeled "Move project to production"
-And I click on the radio labeled "Keep ALL data saved so far"
-And I click on the button labeled "YES, Move to Production Status"
-Then I should see "Project status:  Production"
+        #SETUP randomization
+        When I click on the link labeled "Project Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1"
+        And I upload a "csv" format file located at "import_files/AlloRand rand_group3.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
+        And I upload a "csv" format file located at "import_files/AlloRand rand_group4.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Move project to production"
+        And I click on the radio labeled "Keep ALL data saved so far"
+        And I click on the button labeled "YES, Move to Production Status"
+        Then I should see "Project status:  Production"
 
-#SETUP User Rights
-When I click on the link labeled "User Rights"
-And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role" 
-And I click on the button labeled "Assign to role"
-And I select "1_FullRights" on the dropdown field labeled "Select Role"
-And I click on the button labeled "Assign"
-Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+        #SETUP User Rights
+        When I click on the link labeled "User Rights"
+        And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
+        And I click on the button labeled "Assign to role"
+        And I select "1_FullRights" on the dropdown field labeled "Select Role"
+        And I click on the button labeled "Assign"
+        Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+        And I logout
 
-And I logout
+    Scenario: C.3.30.0900.0100. Normal user cannot modify setup in production.
+        Given I login to REDCap with the user "Test_User1"
+        And I click on the link labeled "My Projects"
+        And I click on the link labeled "C.3.30.0900"
+        And I click on the link labeled "Project Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1"
 
-Scenario: C.3.30.0900.0100. Normal user cannot modify setup in production. 
-Given I login to REDCap with the user "Test_User1"
-And I click on the link labeled "My Projects"
-And I click on the link labeled "C.3.30.0900"
-And I click on the link labeled "Project Setup"
-And I click on the button labeled "Set up randomization"
-And I click on the icon in the column labeled "Setup" and the row labeled "1"
+        #verify unable to erase randomization model
+        And I should see the button labeled "Erase randomization model" that is disabled
 
-# #verify unable to erase randomization model
-And I should see the button labeled "Erase randomization model" that is disabled
+        #Verify unable to modify Stratification
+        And I should see a checkbox labeled "A) Use stratified randomization?" that is disabled
 
-#Verify unable to modify Stratification
-And I should see a checkbox labeled "A) Use stratified randomization?" that is checked
+        #Verify unable to change randomize by group/site
+        And I should see a checkbox labeled "B) Randomize by group/site?" that is disabled
 
-#Verify unable to change randomize by group/site
-And I should see a checkbox labeled "B) Randomize by group/site?" that is disabled
+        #verify unable to change randomization field
+        And I should see the dropdown labeled "rand_group (Randomization group 1)" that is disabled
 
+        #verify unable to upload or download allocation table for use in Development
+        And I should see a button labeled "Download table" in the row labeled "for use in DEVELOPMENT status" that is disabled
 
-#verify unable to change randomization field
-And I should see the dropdown labeled "rand_group (Randomization group 1)" that is disabled
+        #verify unable to upload or download allocation table for use in Production
+        And I should see a button labeled "Download table" in the row labeled "for use in PRODUCTION status" that is disabled
+        And I logout
 
-#verify unable to upload or download allocation table for use in Development
-And I should see a button labeled "Download table" in the row labeled "for use in DEVELOPMENT status" that is disabled
+    Scenario: C.3.30.0900.0200. Admin user unable to revert project to development.
+        Given I login to REDCap with the user "Test_Admin"
+        And I click on the link labeled "My Projects"
+        And I click on the link labeled "C.3.30.0900"
+        And I click on the link labeled "Project Setup"
+        And I click on the link labeled "Other Functionality"
+        Then I should see "Because Randomization is enabled, the project cannot be moved back to Development status."
+        And I should see the button labeled "Move back to Development status" that is disabled
 
-#verify unable to upload or download allocation table for use in Production 
-And I should see a button labeled "Download table" in the row labeled "for use in PRODUCTION status" that is disabled
+    Scenario: C.3.30.0900.0300. Admin cannot modify setup in production.
+        Given I click on the link labeled "Project Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1"
 
-And I logout
+        #verify unable to erase randomization model
+        And I should see the button labeled "Erase randomization model" that is disabled
 
-Scenario: C.3.30.0900.0200. Admin user unable to revert project to development.  
-Given I login to REDCap with the user "Test_Admin"
-And I click on the link labeled "My Projects"
-And I click on the link labeled "C.3.30.0900"
-And I click on the link labeled "Project Setup"
-And I click on the link labeled "Other Functionality"
-Then I should see "Because Randomization is enabled, the project cannot be moved back to Development status."
-And I should see the button labeled "Move back to Development status" that is disabled
+        #Verify unable to modify Stratification
+        And I should see a checkbox labeled "A) Use stratified randomization?" that is disabled
 
-# Scenario: C.3.30.0900.0300. Admin cannot modify setup in production.  
-Given I click on the link labeled "Project Setup"
-And I click on the button labeled "Set up randomization"
-And I click on the icon in the column labeled "Setup" and the row labeled "1"
+        #Verify unable to change randomize by group/site
+        And I should see a checkbox labeled "B) Randomize by group/site?" that is disabled
 
-# # # #verify unable to erase randomization model
-And I should see the button labeled "Erase randomization model" that is disabled
+        #verify unable to change randomization field
+        And I should see the dropdown labeled "rand_group (Randomization group 1)" that is disabled
 
-# # # # #Verify unable to modify Stratification
-And I should see a checkbox labeled "A) Use stratified randomization?" that is checked
+        #verify unable to upload or download allocation table for use in Development
+        And I should see a button labeled "Download table" that is disabled
 
-# #Verify unable to change randomize by group/site
-And I should see a checkbox labeled "B) Randomize by group/site?" that is disabled
+    Scenario: C.3.30.0900.0400. Admin can download existing allocation table in production.
+        #verify able to download allocation table for use in Production
+        Then I should see a link labeled "Upload more allocations? (Administrators only)"
+        And I should see a button labeled "Download table"
+        And I should see "(only REDCap admins may download the allocation table while in production)"
 
-#verify unable to change randomization field
-And I should see the dropdown labeled "rand_group (Randomization group 1)" that is disabled
+        Given I click on the second button labeled "Download table"
+        Then I should see a downloaded file named "RandomizationAllocationTable_Prod.csv"
 
-#verify unable to upload or download allocation table for use in Development
-And I should see a button labeled "Download table" that is disabled 
+    Scenario: C.3.30.0900.0500. Admin cannot modify existing allocation table in production.
+        #verify unable to delete or change allocation table for use in Production
+        And I should NOT see "Delete allocation table?"
 
-Scenario: C.3.30.0900.0400. Admin can download existing allocation table in production.  
-#verify able to download allocation table for use in Production
-Then I should see a link labeled "Upload more allocations? (Administrators only)"
-And I should see a button labeled "Download table"
-And I should see "(only REDCap admins may download the allocation table while in production)"
+    Scenario: C.3.30.0900.0600. Admin can upload additional allocations to existing table in production.
+        #verify able to upload more allocations (Administrators only)
+        When I click on the link labeled "Upload more allocations? (Administrators only)"
+        When I upload a "csv" format file located at "import_files/RandomizationAllocationTable_Prod0900.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
+        Then I should see "Success! New assignments were appended to your existing randomization allocation table!"
 
-Given I click on the second button labeled "Download table"
-Then I should see a downloaded file named "RandomizationAllocationTable_Prod.csv"
-
-# Scenario: C.3.30.0900.0500. Admin cannot modify existing allocation table in production. 
-# #verify unable to delete or change allocation table for use in Production
-And I should NOT see "Delete allocation table?" 
-
-Scenario: C.3.30.0900.0600. Admin can upload additional allocations to existing table in production.
-#verify able to upload more allocations (Administrators only)
-When I click on the link labeled "Upload more allocations? (Administrators only)"
-When I upload a "csv" format file located at "import_files/RandomizationAllocationTable_Prod0900.csv", by clicking the button near "for use in PRODUCTION status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
-Then I should see "Success! New assignments were appended to your existing randomization allocation table!"
-
-#verify logging for the upload
-When I click on the link labeled "Logging"
-Then I should see a table header and rows containing the following values in the logging table:
-| Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-| mm/dd/yyyy hh:mm | test_admin | Manage/Design |Upload randomization allocation table to append - production (rid=2)|
-
-And I logout
-
+        #verify logging for the upload
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
+            | mm/dd/yyyy hh:mm | test_admin | Manage/Design |Upload randomization allocation table to append - production (rid=2)|
+        And I logout
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.0900. - Randomization lock.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.0900. - Randomization lock.feature
@@ -39,6 +39,7 @@ Feature: C.3.30.0900.	User Interface: The system shall ensure users with Randomi
         And I should see the button labeled "Erase randomization model" that is disabled
 
         #Verify unable to modify Stratification
+        And I should see a checkbox labeled "A) Use stratified randomization?" that is checked
         And I should see a checkbox labeled "A) Use stratified randomization?" that is disabled
 
         #Verify unable to change randomize by group/site
@@ -72,6 +73,7 @@ Feature: C.3.30.0900.	User Interface: The system shall ensure users with Randomi
         And I should see the button labeled "Erase randomization model" that is disabled
 
         #Verify unable to modify Stratification
+        And I should see a checkbox labeled "A) Use stratified randomization?" that is checked
         And I should see a checkbox labeled "A) Use stratified randomization?" that is disabled
 
         #Verify unable to change randomize by group/site

--- a/Feature Tests/C/Randomization_30/C.3.30.1000. - Randomization assignment.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1000. - Randomization assignment.feature
@@ -1,109 +1,108 @@
 Feature: C.3.30.1000. User Interface: The system shall support the sequential assignment of allocation table entries to participants based on stratification.
-As a REDCap end user
-I want to see that Randomization is functioning as expected
+    As a REDCap end user
+    I want to see that Randomization is functioning as expected
 
-Scenario: #SETUP - Create new project
-Given I login to REDCap with the user "Test_User1"
-And I create a new project named "C.3.30.1000" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "C.3.30.SeqRand.REDCap.xml", and clicking the "Create Project" button
+    Scenario: #SETUP - Create new project
+        Given I login to REDCap with the user "Test_User1"
+        And I create a new project named "C.3.30.1000" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "C.3.30.SeqRand.REDCap.xml", and clicking the "Create Project" button
 
-#SETUP User Rights
-Scenario: #SETUP- Give User 1 full rights
-When I click on the link labeled "User Rights"
-And I click on the link labeled "test_user1" 
-And I click on the button labeled "Assign to role"
-And I select "1_FullRights" on the dropdown field labeled "select role"
-And I click on the button labeled "Assign"
-Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+    #SETUP User Rights
+    Scenario: #SETUP- Give User 1 full rights
+        When I click on the link labeled "User Rights"
+        And I click on the link labeled "test_user1" 
+        And I click on the button labeled "Assign to role"
+        And I select "1_FullRights" on the dropdown field labeled "select role"
+        And I click on the button labeled "Assign"
+        Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
 
-Scenario: # C.3.30.1000.0300: The system shall reject allocation tables missing required structural elements (e.g., target field column, inconsistent stratum combinations).
-# Test: Upload malformed CSV (e.g., missing redcap_randomization_group). Confirm that REDCap rejects the file with a descriptive error.
-Given I click on the link labeled "Project Setup"
-And I click on the button labeled "Set up randomization"
-And I click on the icon in the column labeled "Setup" and the row labeled "auto_rand"
-And I upload a "csv" format file located at "import_files/AlloRand malformed.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
+    Scenario: #C.3.30.1000.0300: The system shall reject allocation tables missing required structural elements (e.g., target field column, inconsistent stratum combinations).
+        # Test: Upload malformed CSV (e.g., missing redcap_randomization_group). Confirm that REDCap rejects the file with a descriptive error.
+        Given I click on the link labeled "Project Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "auto_rand"
+        And I upload a "csv" format file located at "import_files/AlloRand malformed.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
 
-#Verify: The system rejects allocation tables missing required structural elements.
-Then I should see "ERROR: The following errors occurred. Please address them and try again."
-And I should see "The header variables in the first row of your CSV file are not correct."
+        #Verify: The system rejects allocation tables missing required structural elements.
+        Then I should see "ERROR: The following errors occurred. Please address them and try again."
+        And I should see "The header variables in the first row of your CSV file are not correct."
 
-#Test: Upload malformed CSV (e.g.inconsistent stratum combinations)
-When I click on the button labeled "Return to previous page"
-And I upload a "csv" format file located at "import_files/AlloRand malformed2.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
+        #Test: Upload malformed CSV (e.g.inconsistent stratum combinations)
+        When I click on the button labeled "Return to previous page"
+        And I upload a "csv" format file located at "import_files/AlloRand malformed2.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
 
-#Verify: The system rejects allocation tables with inconsistent stratum combinations
-Then I should see "ERROR: The following errors occurred. Please address them and try again."
-And I should see '"3" is not a valid categorical option for the field "gender"'
+        #Verify: The system rejects allocation tables with inconsistent stratum combinations
+        Then I should see "ERROR: The following errors occurred. Please address them and try again."
+        And I should see '"3" is not a valid categorical option for the field "gender"'
 
-Scenario: # C.3.30.1000.0100: The system shall preserve the order of allocation entries within each stratification group as uploaded, and use that order for assignment.
-#Test: Upload an allocation table with shuffled or non-numeric redcap_randomization_number values. Validate that runtime assignment follows row upload order.
-#Setup Rand_group randomization with shuffled values.
-Given I click on the link labeled "Setup"
-And I click on the button labeled "Set up randomization"
-And I click on the icon in the column labeled "Setup" and the row labeled "1"
-And I upload a "csv" format file located at "import_files/AlloRand rand_groupshuffle.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
-Then I should see "Success"
+    Scenario: #C.3.30.1000.0100: The system shall preserve the order of allocation entries within each stratification group as uploaded, and use that order for assignment.
+        #Test: Upload an allocation table with shuffled or non-numeric redcap_randomization_number values. Validate that runtime assignment follows row upload order.
+        #Setup Rand_group randomization with shuffled values.
+        Given I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "1"
+        And I upload a "csv" format file located at "import_files/AlloRand rand_groupshuffle.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
+        Then I should see "Success"
 
-##Verify records randomized from same gender (stratification group) are assigned to the expected allocation - the first man should be in Placebo and the second man should be Drug A
-When I click on the link labeled "Add / Edit Records"
-And I click on the button labeled "Add new record"
-And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
-And I click on a button labeled "Randomize" 
-And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
-And I click on the button labeled "Randomize"
-Then I should see a dialog containing the following text: 'Record ID "6" was randomized for the field "Randomization group 1" and assigned the value "Placebo" (3).'
-And I click on the button labeled "Close"
-And I click on the button labeled "Save & Exit Form"
+        ##Verify records randomized from same gender (stratification group) are assigned to the expected allocation - the first man should be in Placebo and the second man should be Drug A
+        When I click on the link labeled "Add / Edit Records"
+        And I click on the button labeled "Add new record"
+        And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
+        And I click on a button labeled "Randomize"
+        And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
+        And I click on the button labeled "Randomize"
+        Then I should see a dialog containing the following text: 'Record ID "6" was randomized for the field "Randomization group 1" and assigned the value "Placebo" (3).'
+        And I click on the button labeled "Close"
+        And I click on the button labeled "Save & Exit Form"
 
-When I click on the link labeled "Add / Edit Records"
-And I click on the button labeled "Add new record"
-And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
-And I click on a button labeled "Randomize"
-And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
-And I click on the button labeled "Randomize"
-Then I should see a dialog containing the following text: 'Record ID "7" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).'
-And I click on the button labeled "Close"
-And I click on the button labeled "Save & Exit Form"
+        When I click on the link labeled "Add / Edit Records"
+        And I click on the button labeled "Add new record"
+        And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
+        And I click on a button labeled "Randomize"
+        And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
+        And I click on the button labeled "Randomize"
+        Then I should see a dialog containing the following text: 'Record ID "7" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).'
+        And I click on the button labeled "Close"
+        And I click on the button labeled "Save & Exit Form"
 
-#Verify records allocated to a different stratification group are not assigned simple the next code in the list, but instead assigned the next code for their stratification group.  The next record in the Other group should be assigned to Group A and not to Group B.
-When I click on the link labeled "Add / Edit Records"
-And I click on the button labeled "Add new record"
-And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
-And I click on a button labeled "Randomize"
-And I click on the radio labeled "Other" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
-And I click on the button labeled "Randomize"
-Then I should see a dialog containing the following text: 'Record ID "8" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).' 
-And I click on the button labeled "Close"
-And I click on the button labeled "Save & Exit Form"
+        #Verify records allocated to a different stratification group are not assigned simple the next code in the list, but instead assigned the next code for their stratification group.  The next record in the Other group should be assigned to Group A and not to Group B.
+        When I click on the link labeled "Add / Edit Records"
+        And I click on the button labeled "Add new record"
+        And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
+        And I click on a button labeled "Randomize"
+        And I click on the radio labeled "Other" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
+        And I click on the button labeled "Randomize"
+        Then I should see a dialog containing the following text: 'Record ID "8" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).' 
+        And I click on the button labeled "Close"
+        And I click on the button labeled "Save & Exit Form"
 
-Scenario: # C.3.30.1000.0200: The system shall assign the next available allocation entry sequentially to each new record.
-# Test: Upload a table with duplicate values or text labels in redcap_randomization_number. Confirm that upload succeeds and assignments function correctly.
-#Setup automatic randomization with duplicate, non numerical values.
-Given I click on the link labeled "Setup"
-And I click on the button labeled "Set up randomization"
-And I click on the icon in the column labeled "Setup" and the row labeled "auto_rand"
-And I upload a "csv" format file located at "import_files/AlloRand auto_randtextduplicate.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
-Then I should see "Success"
+    Scenario: #C.3.30.1000.0200: The system shall assign the next available allocation entry sequentially to each new record.
+        # Test: Upload a table with duplicate values or text labels in redcap_randomization_number. Confirm that upload succeeds and assignments function correctly.
+        #Setup automatic randomization with duplicate, non numerical values.
+        Given I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the icon in the column labeled "Setup" and the row labeled "auto_rand"
+        And I upload a "csv" format file located at "import_files/AlloRand auto_randtextduplicate.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload File" to upload the file
+        Then I should see "Success"
 
-# #Verify records randomized from same gender (stratification group) are assigned to the expected allocation (next sequential allocation for that strat group) - the first man should be in Group 1 (A) and the second man should also be in Group 1 (A)
-When I click on the link labeled "Add / Edit Records"
-And I click on the button labeled "Add new record"
-And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
-And I click on the second button labeled "Randomize"
-And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
-And I click on the button labeled "Randomize"
-Then I should see a dialog containing the following text: 'Record ID "9" was randomized for the field "Automatic Randomization" and assigned the value "Group 1" (A).'
-And I click on the button labeled "Close"
-And I click on the button labeled "Save & Exit Form"
+        #Verify records randomized from same gender (stratification group) are assigned to the expected allocation (next sequential allocation for that strat group) - the first man should be in Group 1 (A) and the second man should also be in Group 2 (B)
+        When I click on the link labeled "Add / Edit Records"
+        And I click on the button labeled "Add new record"
+        And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
+        And I click on the second button labeled "Randomize"
+        And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
+        And I click on the button labeled "Randomize"
+        Then I should see a dialog containing the following text: 'Record ID "9" was randomized for the field "Automatic Randomization" and assigned the value "Group 1" (A).'
+        And I click on the button labeled "Close"
+        And I click on the button labeled "Save & Exit Form"
 
-When I click on the link labeled "Add / Edit Records"
-And I click on the button labeled "Add new record"
-And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
-And I click on a second button labeled "Randomize" 
-And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
-And I click on the button labeled "Randomize"
-Then I should see a dialog containing the following text: 'Record ID "10" was randomized for the field "Automatic Randomization" and assigned the value "Group 2" (B).'
-And I click on the button labeled "Close"
-And I click on the button labeled "Save & Exit Form"
-
-And I logout
+        When I click on the link labeled "Add / Edit Records"
+        And I click on the button labeled "Add new record"
+        And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
+        And I click on a second button labeled "Randomize"
+        And I click on the radio labeled "Man" in the row labeled "Do you describe yourself as a man, a woman, or in some other way?"
+        And I click on the button labeled "Randomize"
+        Then I should see a dialog containing the following text: 'Record ID "10" was randomized for the field "Automatic Randomization" and assigned the value "Group 2" (B).'
+        And I click on the button labeled "Close"
+        And I click on the button labeled "Save & Exit Form"
+        And I logout
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.1100. - Randomization rights execute.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1100. - Randomization rights execute.feature
@@ -2,7 +2,7 @@ Feature: C.3.30.1100.	User Interface: The system shall ensure users with Randomi
   As a REDCap end user
   I want to see that Randomization is functioning as expected
 
- Scenario: #SETUP project with randomization enabled
+  Scenario: #SETUP project with randomization enabled
     Given I login to REDCap with the user "Test_User1"
     And I create a new project named "C.3.30.1100." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
     
@@ -30,9 +30,7 @@ Feature: C.3.30.1100.	User Interface: The system shall ensure users with Randomi
     And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
     And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
     And I click on the button labeled "Save randomization model"
-
     Then I should see "Success! The randomization model has been saved!"
-    
     #Adding valid allocation table
     When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
     Then I should see "Already uploaded"
@@ -42,14 +40,14 @@ Feature: C.3.30.1100.	User Interface: The system shall ensure users with Randomi
     And I login to REDCap with the user "Test_User2"
     And I click on the link labeled "My Projects"
     And I click on the link labeled "C.3.30.1100."
-        # Create Record for one stratum
+    #Create Record for one stratum
     When I click on the link labeled "Add / Edit Records"
     And I select "1" on the dropdown field labeled "Choose an existing Record ID"
     And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
     And I select the radio option "Yes" for the field labeled "Stratification 1"
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 1 successfully edited."
-        # Ensure randomization button isn't available
+    #Ensure randomization button isn't available
     When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
     Then I should NOT see a button labeled "Randomize"
     And I should see "Not yet randomized"
@@ -66,14 +64,18 @@ Feature: C.3.30.1100.	User Interface: The system shall ensure users with Randomi
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 2 successfully edited."
     And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+    Then I should NOT see "Already randomized"
     And I click on the button labeled "Randomize" 
     Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
     And I click on the button labeled "Randomize"
     Then I should see "was randomized for"
     And I click on the button labeled "Close"
+    Then I should see "Already randomized"
+    And I should see the radio labeled "Randomization group 1" with option "Drug A" selected
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 2 successfully edited."
 
+  Scenario: C.3.30.1100.0400 User with randomize rights cannot modify randomized record.
     #Verify "Randomization group" field is populated with an expected value (i.e., what was selected from the allocation table).
     When I click on the link labeled "Add / Edit Records"
     And I select "2" on the dropdown field labeled "Choose an existing Record ID"
@@ -92,16 +94,7 @@ Feature: C.3.30.1100.	User Interface: The system shall ensure users with Randomi
             |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        | 
 
   Scenario: C.3.30.1100.0300. Record's randomized value matches allocation table.  
-    # This feature test is REDUNDANT and can be viewed in C.3.30.0200 and C.3.30.0300
+    #This feature test is REDUNDANT and can be viewed in C.3.30.0200 and C.3.30.0300
 
-  Scenario: C.3.30.1100.0400 User with randomize rights cannot modify randomized record.
-    When I click on the link labeled "Add / Edit Records"
-    And I select "2" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    Then I should see "Already randomized"
-    And I should see a radio labeled "Drug A" in the row labeled "Already randomized" that is disabled
-    And I should see a radio labeled "Drug B" in the row labeled "Already randomized" that is disabled
-    And I should see a radio labeled "Placebo" in the row labeled "Already randomized" that is disabled
-
-Given I logout
+    Given I logout
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.1200. - Randomization audit trail.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1200. - Randomization audit trail.feature
@@ -1,65 +1,74 @@
 Feature: C.3.30.1200.	User Interface: The system shall support an audit trail showing who randomized the record and the date-time of randomization.
+   As a REDCap end user
+   I want to see that Randomization is functioning as expected
 
-Scenario: #SETUP - Create new project
-Given I login to REDCap with the user "Test_User1"
-And I create a new project named "C.3.30.1200" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
+   Scenario: #SETUP - Create new project
+      Given I login to REDCap with the user "Test_User1"
+      And I create a new project named "C.3.30.1200" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
 
-Scenario: #SETUP User Rights
-When I click on the link labeled "User Rights"
-And I click on the link labeled "Test User1" 
-And I click on the button labeled "Assign to role"
-And I select "1_FullRights" on the dropdown field labeled "select role"
-And I click on the button labeled "Assign"
-Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+   Scenario: #SETUP User Rights
+      When I click on the link labeled "User Rights"
+      And I click on the link labeled "Test User1"
+      And I click on the button labeled "Assign to role"
+      And I select "1_FullRights" on the dropdown field labeled "select role"
+      And I click on the button labeled "Assign"
+      Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
 
-#SETUP Creating randomiztion stategy and adding allocation table.
-When I click on the link labeled "Setup"
-And I click on the button labeled "Set up randomization"
-And I click on the button labeled "Add new randomization model"
-And I select "rand_blind (Blinded randomization)" on the first dropdown field labeled "- select a field -"
-And I click on the button labeled "Save randomization model"
-Then I should see "Success! The randomization model has been saved!"
-And I upload a "csv" format file located at "import_files/AlloRand blind1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-And I click on the link labeled "Summary"
-And I click on the button labeled "Add new randomization model"
-And I select "rand_group (Randomization group 1)" on the first dropdown field labeled "- select a field -"
-And I click on the button labeled "Save randomization model"
-Then I should see "Success! The randomization model has been saved!"
-And I upload a "csv" format file located at "import_files/AlloRand open1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+      #SETUP Creating randomiztion stategy and adding allocation table.
+      When I click on the link labeled "Setup"
+      And I click on the button labeled "Set up randomization"
+      And I click on the button labeled "Add new randomization model"
+      And I select "rand_blind (Blinded randomization)" on the first dropdown field labeled "- select a field -"
+      And I click on the button labeled "Save randomization model"
+      Then I should see "Success! The randomization model has been saved!"
+      And I upload a "csv" format file located at "import_files/AlloRand blind1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+      And I click on the link labeled "Summary"
+      And I click on the button labeled "Add new randomization model"
+      And I select "rand_group (Randomization group 1)" on the first dropdown field labeled "- select a field -"
+      And I click on the button labeled "Save randomization model"
+      Then I should see "Success! The randomization model has been saved!"
+      And I upload a "csv" format file located at "import_files/AlloRand open1.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
 
-Scenario: #C.3.30.1200.0100. Logging of record's randomization includes user and timestamp.  
-Given I click on the link labeled "Add / Edit Records"
-And I click on the button labeled "Add new record"
-And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
-And I click on the first button labeled "Randomize"
-And I should see "Below you may perform randomization"
-And I click on the button labeled "Randomize"
-Then I should see a dialog containing the following text: 'Record ID "6" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).'
-And I click on the button labeled "Close"
-And I click on the button labeled "Randomize"
-And I should see "Below you may perform randomization"
-And I click on the button labeled "Randomize"
-Then I should see a dialog containing the following text: 'Record ID "6" was randomized for the field "Blinded randomization" and assigned the value "1".'
-And I click on the button labeled "Close"
-And I click on the button labeled "Save & Exit Form"
+   Scenario: #C.3.30.1200.0100. Logging of record's randomization includes user and timestamp.
+      Given I click on the link labeled "Add / Edit Records"
+      And I click on the button labeled "Add new record"
+      And I click the bubble for the row labeled "Randomization" instrument on the column labeled "Status"
+      And I click on the first button labeled "Randomize"
+      And I should see "Below you may perform randomization"
+      And I should NOT see "Already randomized"
+      And I click on the button labeled "Randomize"
+      Then I should see a dialog containing the following text: 'Record ID "6" was randomized for the field "Randomization group 1" and assigned the value "Drug A" (1).'
+      And I click on the button labeled "Close"
+      Then I should see the radio labeled "Randomization group 1" with option "Drug A" selected
+      And I should see a radio labeled "Drug A" in the row labeled "Randomization group 1" that is disabled
+      And I should see a radio labeled "Drug B" in the row labeled "Randomization group 1" that is disabled
+      And I should see a radio labeled "Placebo" in the row labeled "Randomization group 1" that is disabled
+      And I should see "Already randomized"
+      And I click on the button labeled "Randomize"
+      And I should see "Below you may perform randomization"
+      And I click on the button labeled "Randomize"
+      Then I should see a dialog containing the following text: 'Record ID "6" was randomized for the field "Blinded randomization" and assigned the value "1".'
+      And I click on the button labeled "Close"
+      Then I should see "1" in the data entry form field "Blinded randomization"
+      And I click on the button labeled "Save & Exit Form"
 
-Scenario: #C.3.30.1200.0200 Logging includes the target field allocation value.
-#VERIFY: Logging of record's randomization includes user and timestamp.  
-When I click on the link labeled "Logging"
-Then I should see a table header and rows containing the following values in the logging table:
-   | Time / Date       | Username   | Action             | List of Data Changes OR Fields Exported     |
-   | mm/dd/yyyy hh:mm | test_user1 | Randomize Record 6 | Randomize record                             |
-   | mm/dd/yyyy hh:mm | test_user1 | Update record 6    | rand_blind = '1' |
-   | mm/dd/yyyy hh:mm | test_user1 | Randomize Record 6 | Randomize record                             |
-   | mm/dd/yyyy hh:mm | test_user1 | Create record 6    | record_id = '6', rand_group = '1', randomization_complete = '0' |
-   
+   Scenario: #C.3.30.1200.0200 Logging includes the target field allocation value.
+      #VERIFY: Logging of record's randomization includes user and timestamp.
+      When I click on the link labeled "Logging"
+      Then I should see a table header and rows containing the following values in the logging table:
+         | Time / Date       | Username   | Action            | List of Data Changes OR Fields Exported     |
+         | mm/dd/yyyy hh:mm | test_user1 | Randomize Record 6 | Randomize record                            |
+         | mm/dd/yyyy hh:mm | test_user1 | Update record 6    | rand_blind = '1'                            |
+         | mm/dd/yyyy hh:mm | test_user1 | Randomize Record 6 | Randomize record                            |
+         | mm/dd/yyyy hh:mm | test_user1 | Create record 6    | record_id = '6', rand_group = '1', randomization_complete = '0' |
 
-#C.3.30.1200.0300 Allocation group is visible in logging for open models.
-# This feature test is REDUNDANT and can be viewed in C.3.30.1200.0200 where "rand_group = '1'"
 
-Scenario: # C.3.30.1200.0400 Concealed allocation group remains hidden in logging for blinded models.
-#VERIFY: Concealed allocation group remains hidden in logging for blinded models.
-And I should NOT see "Group A"  
+      #C.3.30.1200.0300 Allocation group is visible in logging for open models.
+      # This feature test is REDUNDANT and can be viewed in C.3.30.1200.0200 where "rand_group = '1'"
 
-And I logout
+   Scenario: #C.3.30.1200.0400 Concealed allocation group remains hidden in logging for blinded models.
+      #VERIFY: Concealed allocation group remains hidden in logging for blinded models.
+      And I should NOT see "Group A"
+
+      And I logout
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.1400. - Randomization model.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1400. - Randomization model.feature
@@ -1,79 +1,78 @@
 Feature: C.3.30.1400 – User Interface: The system shall support single randomization per model and multiple randomizations per record.
-As a REDCap end user
-I want to see that Randomization is functioning as expected
+    As a REDCap end user
+    I want to see that Randomization is functioning as expected
 
-Scenario: #SETUP - Create new project
-    Given I login to REDCap with the user "Test_User1"
-    And I create a new project named "C.3.30.1400" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
+    Scenario: #SETUP - Create new project
+        Given I login to REDCap with the user "Test_User1"
+        And I create a new project named "C.3.30.1400" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
 
-    #SETUP- Assign rights for user with randomization rights
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
-    And I click on the button labeled "Assign to role"
-    And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
-    When I click on the button labeled "Assign"
-    Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
+        #SETUP- Assign rights for user with randomization rights
+        When I click on the link labeled "User Rights"
+        And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
+        And I click on the button labeled "Assign to role"
+        And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
+        When I click on the button labeled "Assign"
+        Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
 
-    #SETUP- Randomization model 1 setup
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "A) Use stratified randomization?"
-    And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-    When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Success! The randomization allocation table was created!"
+        #SETUP- Randomization model 1 setup
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I check the checkbox labeled "A) Use stratified randomization?"
+        And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
+        And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+        When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+        Then I should see "Success! The randomization allocation table was created!"
 
-    #SETUP- Randomization model 2 setup
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I select "rand_group_6 (Randomization group 6)" on the first dropdown field labeled "- select a field -"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-    When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate_1basic.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Success! The randomization allocation table was created!"
+        #SETUP- Randomization model 2 setup
+        When I click on the link labeled "Setup"
+        And I click on the button labeled "Set up randomization"
+        And I click on the button labeled "Add new randomization model"
+        And I select "rand_group_6 (Randomization group 6)" on the first dropdown field labeled "- select a field -"
+        And I click on the button labeled "Save randomization model"
+        Then I should see "Success! The randomization model has been saved!"
+        When I upload a "csv" format file located at "import_files/RandomizationAllocationTemplate_1basic.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+        Then I should see "Success! The randomization allocation table was created!"
 
-Scenario:#C.3.30.1400.0100. A record can be randomized across distinct models (e.g., Model A, Model B).
-    #Randomizing to first model
-    When I click on the link labeled "Add / Edit Records"
-    And I select "1" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
-    And I select the radio option "Yes" for the field labeled "Stratification 1"
-    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-    Then I should see "Record ID 1 successfully edited."
-    When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    And I click on the first button labeled "Randomize"
-    Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
-    And I click on the button labeled "Randomize"
-    Then I should see "was randomized for"
-    And I click on the button labeled "Close"
+    Scenario:#C.3.30.1400.0100. A record can be randomized across distinct models (e.g., Model A, Model B).
+        #Randomizing to first model
+        When I click on the link labeled "Add / Edit Records"
+        And I select "1" on the dropdown field labeled "Choose an existing Record ID"
+        And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
+        And I select the radio option "Yes" for the field labeled "Stratification 1"
+        And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+        Then I should see "Record ID 1 successfully edited."
+        When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+        And I click on the first button labeled "Randomize"
+        Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
+        And I click on the button labeled "Randomize"
+        Then I should see "was randomized for"
+        And I click on the button labeled "Close"
 
-    #Randomizing to second model
-    When I click on the button labeled "Randomize"
-    Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
-    And I click on the button labeled "Randomize"
-    Then I should see "was randomized for"
-    And I click on the button labeled "Close"
+        #Randomizing to second model
+        When I click on the button labeled "Randomize"
+        Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
+        And I click on the button labeled "Randomize"
+        Then I should see "was randomized for"
+        And I click on the button labeled "Close"
 
-    #VERIFY: Logging
-    Given I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-      | Username   | Action             | List of Data Changes OR Fields Exported      |
-      | test_user1 | Randomize Record 1 | Randomize record                             |
-      | test_user1 | Update record 1    | rand_group_6 = '1'                           |
-      | test_user1 | Randomize Record 1 | Randomize record                             |
-      | test_user1 | Update record 1    | rand_group = '1'                             |
+        #VERIFY: Logging
+        Given I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+        | Username   | Action             | List of Data Changes OR Fields Exported      |
+        | test_user1 | Randomize Record 1 | Randomize record                             |
+        | test_user1 | Update record 1    | rand_group_6 = '1'                           |
+        | test_user1 | Randomize Record 1 | Randomize record                             |
+        | test_user1 | Update record 1    | rand_group = '1'                             |
 
+    Scenario:#C.3.30.1400.0200. The system shall prevent a record from being randomized more than once within the same model.
+        When I click on the link labeled "Add / Edit Records"
+        And I select "1" on the dropdown field labeled "Choose an existing Record ID"
+        And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+        Then I should see "Already randomized"
+        And I should NOT see a button labeled "Randomize"
 
-Scenario:#C.3.30.1400.0200. The system shall prevent a record from being randomized more than once within the same model.
-    When I click on the link labeled "Add / Edit Records"
-    And I select "1" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    Then I should see "Already randomized"
-    And I should NOT see a button labeled "Randomize"
-
-Given I logout
+        Given I logout
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.1400. - Randomization model.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1400. - Randomization model.feature
@@ -20,7 +20,7 @@ Feature: C.3.30.1400 – User Interface: The system shall support single randomi
         And I click on the button labeled "Add new randomization model"
         And I check the checkbox labeled "A) Use stratified randomization?"
         And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-        And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
+        And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
         And I click on the button labeled "Save randomization model"
         Then I should see "Success! The randomization model has been saved!"
         When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file

--- a/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
@@ -105,12 +105,12 @@ Feature: C.3.30.1500.	User Interface: The system shall support blinded and open 
                 When I click on the link labeled "Data Exports, Reports, and Stats"
                 And I click on the button labeled "View Report"
                 Then I should see a table header and rows containing the following values in the report data table:
-                        | Record ID | Stratification 1 |
-                        | 1         |                       |
-                        | 2         | Yes (1)               |
-                        | 3         |                       |
-                        | 4         |                       |
-                        | 5         |                       |
+                        | Record ID | Stratification 1 | Randomization group 1 |
+                        | 1         |                  |                       |
+                        | 2         | Yes (1)          | Drug A (1)            |
+                        | 3         |                  |                       |
+                        | 4         |                  |                       |
+                        | 5         |                  |                       |
 
         Scenario: #C.3.30.1500.0300. All users with export rights can export randomized records, seeing the allocation assigned to each record as displayed in the record view.
                 Given I click on the link labeled "Data Exports, Reports, and Stats"

--- a/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
@@ -1,192 +1,168 @@
 Feature: C.3.30.1500.	User Interface: The system shall support blinded and open randomization models, with access to allocation details based on user permissions and model setup.
-As a REDCap end user
-I want to see that Randomization is functioning as expected
+        As a REDCap end user
+        I want to see that Randomization is functioning as expected
 
-Scenario: #SETUP project with randomization enabled
-    Given I login to REDCap with the user "Test_User1"
-    And I create a new project named "C.3.30.1500." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
-    
-    #Adding user rights Test_User1 (with randomize rights)
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
-    And I click on the button labeled "Assign to role"
-    And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
-    When I click on the button labeled "Assign"
-    Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
-      
-    #Adding user Test_User2 (without randomize rights)
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User2" into the field with the placeholder text of "Add new user"
-    And I click on the button labeled "Add with custom rights"
-    And I click on the checkbox labeled "Project Design and Setup"
-    And I uncheck the checkbox labeled "Setup"
-    And I click on the button labeled "Add user"
-    Then I should see 'User "Test_User2" was successfully added'
-    
-    #SETUP Creating randomiztion stategy and adding allocation table.
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "A) Use stratified randomization?"
-    And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-    When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
+        Scenario: #SETUP project with randomization enabled
+                Given I login to REDCap with the user "Test_User1"
+                And I create a new project named "C.3.30.1500." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
 
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model" 
-    And I select "rand_blind" on the dropdown field labeled "- select a field -"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-    When I upload a "csv" format file located at "import_files/C3.30BlindAllocationTemplate.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
+                #Adding user rights Test_User1 (with randomize rights)
+                When I click on the link labeled "User Rights"
+                And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
+                And I click on the button labeled "Assign to role"
+                And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
+                When I click on the button labeled "Assign"
+                Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
 
-    #SETUP -  Create a record and randomize with both Open and Blinded Randomization fields.
-    When I click on the link labeled "Add / Edit Records"
-    And I select "2" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
-    And I select the radio option "Yes" for the field labeled "Stratification 1"
-    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-    Then I should see "Record ID 2 successfully edited."
-    When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    And I click on the first button labeled "Randomize"
-    Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
-    When I click on the button labeled "Randomize"
-    Then I should see "was randomized for"
-    And I click on the button labeled "Close"
+                #Adding user Test_User2 (without randomize rights)
+                When I click on the link labeled "User Rights"
+                And I enter "Test_User2" into the field with the placeholder text of "Add new user"
+                And I click on the button labeled "Add with custom rights"
+                And I click on the checkbox labeled "Project Design and Setup"
+                And I uncheck the checkbox labeled "Setup"
+                And I click on the button labeled "Add user"
+                Then I should see 'User "Test_User2" was successfully added'
 
-    When I click on the button labeled "Randomize"
-    Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
-    When I click on the button labeled "Randomize"
-    Then I should see "was randomized for"
-    And I click on the button labeled "Close"
-    
-    When I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-    Then I should see "Record ID 2 successfully edited."
-   
-Scenario: #C.3.30.1500.0100. For a blinded model, users without setup rights will see only a concealed allocation code in the record and reports, with no visible group assignment.  
-    Given I logout
-    And I login to REDCap with the user "Test_User2"
-    And I click on the link labeled "Add / Edit Records"
-    And I select "2" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+                #SETUP Creating randomiztion stategy and adding allocation table.
+                When I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the button labeled "Add new randomization model"
+                And I check the checkbox labeled "A) Use stratified randomization?"
+                And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
+                And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
+                And I click on the button labeled "Save randomization model"
+                Then I should see "Success! The randomization model has been saved!"
+                When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+                Then I should see "Already uploaded"
 
-    #Verify the user can only see a concealed allocation code in the record with no visible group assignment.  
-    Then I should see "Already randomized"
-    And I should see "01" in the data entry form field "Blinded randomization" 
-    
-    #Verify the user can only see a concealed allocation code in reports with no visible group assignment.  
-    When I click on the link labeled "Data Exports, Reports, and Stats"
-    And I click on the button labeled "View Report"
-    Then I should see a table header and rows containing the following values in the report data table:
-            | Record ID | Blinded randomization |
-            | 1         |                       |
-            | 2         | 01                    |
-            | 3         |                       |
-            | 4         |                       |
-            | 5         |                       |
+                When I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the button labeled "Add new randomization model"
+                And I select "rand_blind" on the dropdown field labeled "- select a field -"
+                And I click on the button labeled "Save randomization model"
+                Then I should see "Success! The randomization model has been saved!"
+                When I upload a "csv" format file located at "import_files/C3.30BlindAllocationTemplate.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+                Then I should see "Already uploaded"
 
-  Scenario: #C.3.30.1500.0200. For an open model, users without setup rights can view the assigned group allocation directly in the record and reports.  
-    Given I click on the link labeled "Add / Edit Records"
-    And I select "2" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+                #SETUP -  Create a record and randomize with both Open and Blinded Randomization fields.
+                When I click on the link labeled "Add / Edit Records"
+                And I select "2" on the dropdown field labeled "Choose an existing Record ID"
+                And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
+                And I select the radio option "Yes" for the field labeled "Stratification 1"
+                And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+                Then I should see "Record ID 2 successfully edited."
+                When I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+                And I click on the first button labeled "Randomize"
+                Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
+                When I click on the button labeled "Randomize"
+                Then I should see "was randomized for"
+                And I click on the button labeled "Close"
 
-    #Verify the user can see the assigned group allocation code directly in the record
-    Then I should see "Already randomized"
-    And I should see a radio labeled "Drug A" in the row labeled "Randomization group 1" that is disabled
-    And I should see a radio labeled "Drug B" in the row labeled "Randomization group 1" that is disabled
-    And I should see a radio labeled "Placebo" in the row labeled "Randomization group 1" that is disabled
-   
-    #Verify the user can see the assigned group allocation code directly in reports
-    When I click on the link labeled "Data Exports, Reports, and Stats"
-    And I click on the button labeled "View Report"
-    Then I should see a table header and rows containing the following values in the report data table:
-            | Record ID | Stratification 1 |
-            | 1         |                       |
-            | 2         | Yes (1)               |
-            | 3         |                       |
-            | 4         |                       |
-            | 5         |                       |
+                When I click on the button labeled "Randomize"
+                Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
+                When I click on the button labeled "Randomize"
+                Then I should see "was randomized for"
+                And I click on the button labeled "Close"
 
-Scenario: #C.3.30.1500.0300. All users with export rights can export randomized records, seeing the allocation assigned to each record as displayed in the record view.  
-    Given I click on the link labeled "Data Exports, Reports, and Stats"
-    And I click on the button labeled "View Report"
-    Then I should see a table header and rows containing the following values in the report data table:
-            | Record ID | Stratification 1 | Randomization group | Blinded randomization|
-            | 1         |                  |                     |                      |
-            | 2         | Yes (1)          | Drug A (1)          |01                    |
-            | 3         |                  |                     |                      |
-            | 4         |                  |                     |                      |
-            | 5         |                  |                     |                      |
-    
-Scenario:#C.3.30.1500.0400. Only users with setup rights or admin privileges can access and export the full allocation table directly from the setup interface, regardless of model type.
-    When I click on the link labeled "Setup"
-    Then I should see the button labeled "Set up randomization" that is disabled
-    Given I logout
+                When I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+                Then I should see "Record ID 2 successfully edited."
 
-    #Verify user with setup rights can access and export the full allocation table directly from the setup interface, (rand_group) open randomization type
-    Given I login to REDCap with the user "Test_User1"
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "rand_group" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the button labeled "Download table"
-    Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
+        Scenario: #C.3.30.1500.0100. For a blinded model, users without setup rights will see only a concealed allocation code in the record and reports, with no visible group assignment.
+                Given I logout
+                And I login to REDCap with the user "Test_User2"
+                And I click on the link labeled "Add / Edit Records"
+                And I select "2" on the dropdown field labeled "Choose an existing Record ID"
+                And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
 
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
+                #Verify the user can only see a concealed allocation code in the record with no visible group assignment.
+                Then I should see "Already randomized"
+                And I should see "01" in the data entry form field "Blinded randomization"
 
-    #Verify User with setup rights can access and export the full allocation table directly from the setup interface, (rand_blind) blind randomization type
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "rand_blind" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the button labeled "Download table"
-    Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
+        Scenario: #C.3.30.1500.0200. For an open model, users without setup rights can view the assigned group allocation directly in the record and reports.
+                #Verify the user can see the assigned group allocation code directly in the record
+                And I should see the radio labeled "Randomization group 1" with option "Drug A" selected
+                And I should see a radio labeled "Drug A" in the row labeled "Randomization group 1" that is disabled
+                And I should see a radio labeled "Drug B" in the row labeled "Randomization group 1" that is disabled
+                And I should see a radio labeled "Placebo" in the row labeled "Randomization group 1" that is disabled
 
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
-    Given I logout
+        Scenario: #C.3.30.1500.0300. All users with export rights can export randomized records, seeing the allocation assigned to each record as displayed in the record view.
+                Given I click on the link labeled "Data Exports, Reports, and Stats"
+                And I click on the button labeled "View Report"
+                #Verify the user can see the assigned group allocation code directly in reports
+                #Verify the user can only see a concealed allocation code in reports with no visible group assignment.
+                Then I should see a table header and rows containing the following values in the report data table:
+                        | Record ID | Stratification 1 | Randomization group | Blinded randomization|
+                        | 1         |                  |                     |                      |
+                        | 2         | Yes (1)          | Drug A (1)          | 01                   |
+                        | 3         |                  |                     |                      |
+                        | 4         |                  |                     |                      |
+                        | 5         |                  |                     |                      |
 
-    #Verify Admin User can access and export the full allocation table directly from the setup interface, (rand_group) open randomization type
-    Given I login to REDCap with the user "Test_Admin"
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "rand_group" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the button labeled "Download table"
-    Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
+        Scenario:#C.3.30.1500.0400. Only users with setup rights or admin privileges can access and export the full allocation table directly from the setup interface, regardless of model type.
+                When I click on the link labeled "Setup"
+                Then I should see the button labeled "Set up randomization" that is disabled
+                Given I logout
 
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
+                #Verify user with setup rights can access and export the full allocation table directly from the setup interface, (rand_group) open randomization type
+                Given I login to REDCap with the user "Test_User1"
+                And I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the icon in the column labeled "Setup" and the row labeled "strat_1"
+                Then I should see "STEP 3: Upload your allocation table (CSV file)"
+                When I click on the button labeled "Download table"
+                Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
 
-    #Verify User with setup rights can access and export the full allocation table directly from the setup interface, (rand_blind) blind randomization type
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Setup" and the row labeled "rand_blind" 
-    Then I should see "STEP 3: Upload your allocation table (CSV file)"
-    When I click on the button labeled "Download table"
-    Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
+                #VERIFY_log Randomization saved in logging table
+                When I click on the link labeled "Logging"
+                Then I should see a table header and rows containing the following values in the logging table:
+                        | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported            |
+                        | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
 
-    #VERIFY_log Randomization saved in logging table
-    When I click on the link labeled "Logging"
-    Then I should see a table header and rows containing the following values in the logging table:
-            | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported           |
-            | mm/dd/yyyy hh:mm | test_admin | Manage/Design |Download randomization allocation table (development)|
-            | mm/dd/yyyy hh:mm | test_admin | Manage/Design |Download randomization allocation table (development)|
+                #Verify User with setup rights can access and export the full allocation table directly from the setup interface, (rand_blind) blind randomization type
+                When I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the icon in the column labeled "Setup" and the row labeled "rand_blind"
+                Then I should see "STEP 3: Upload your allocation table (CSV file)"
+                When I click on the button labeled "Download table"
+                Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
 
-Given I logout
+                #VERIFY_log Randomization saved in logging table
+                When I click on the link labeled "Logging"
+                Then I should see a table header and rows containing the following values in the logging table:
+                        | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported             |
+                        | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
+                        | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
+                Given I logout
+
+                #Verify Admin User can access and export the full allocation table directly from the setup interface, (rand_group) open randomization type
+                Given I login to REDCap with the user "Test_Admin"
+                And I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the icon in the column labeled "Setup" and the row labeled "strat_1"
+                Then I should see "STEP 3: Upload your allocation table (CSV file)"
+                When I click on the button labeled "Download table"
+                Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
+
+                #VERIFY_log Randomization saved in logging table
+                When I click on the link labeled "Logging"
+                Then I should see a table header and rows containing the following values in the logging table:
+                        | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported             |
+                        | mm/dd/yyyy hh:mm | test_user1 | Manage/Design |Download randomization allocation table (development)|
+
+                #Verify User with setup rights can access and export the full allocation table directly from the setup interface, (rand_blind) blind randomization type
+                When I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the icon in the column labeled "Setup" and the row labeled "rand_blind"
+                Then I should see "STEP 3: Upload your allocation table (CSV file)"
+                When I click on the button labeled "Download table"
+                Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
+
+                #VERIFY_log Randomization saved in logging table
+                When I click on the link labeled "Logging"
+                Then I should see a table header and rows containing the following values in the logging table:
+                        | Time / Date      | Username   | Action        | List of Data Changes OR Fields Exported             |
+                        | mm/dd/yyyy hh:mm | test_admin | Manage/Design |Download randomization allocation table (development)|
+                        | mm/dd/yyyy hh:mm | test_admin | Manage/Design |Download randomization allocation table (development)|
+
+                Given I logout
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
@@ -78,12 +78,39 @@ Feature: C.3.30.1500.	User Interface: The system shall support blinded and open 
                 Then I should see "Already randomized"
                 And I should see "01" in the data entry form field "Blinded randomization"
 
+                #Verify the user can only see a concealed allocation code in reports with no visible group assignment.  
+                When I click on the link labeled "Data Exports, Reports, and Stats"
+                And I click on the button labeled "View Report"
+                Then I should see a table header and rows containing the following values in the report data table:
+                        | Record ID | Blinded randomization |
+                        | 1         |                       |
+                        | 2         | 01                    |
+                        | 3         |                       |
+                        | 4         |                       |
+                        | 5         |                       |
+
         Scenario: #C.3.30.1500.0200. For an open model, users without setup rights can view the assigned group allocation directly in the record and reports.
+                Given I click on the link labeled "Add / Edit Records"
+                And I select "2" on the dropdown field labeled "Choose an existing Record ID"
+                And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+
                 #Verify the user can see the assigned group allocation code directly in the record
                 And I should see the radio labeled "Randomization group 1" with option "Drug A" selected
+                Then I should see "Already randomized"
                 And I should see a radio labeled "Drug A" in the row labeled "Randomization group 1" that is disabled
                 And I should see a radio labeled "Drug B" in the row labeled "Randomization group 1" that is disabled
                 And I should see a radio labeled "Placebo" in the row labeled "Randomization group 1" that is disabled
+
+                #Verify the user can see the assigned group allocation code directly in reports
+                When I click on the link labeled "Data Exports, Reports, and Stats"
+                And I click on the button labeled "View Report"
+                Then I should see a table header and rows containing the following values in the report data table:
+                        | Record ID | Stratification 1 |
+                        | 1         |                       |
+                        | 2         | Yes (1)               |
+                        | 3         |                       |
+                        | 4         |                       |
+                        | 5         |                       |
 
         Scenario: #C.3.30.1500.0300. All users with export rights can export randomized records, seeing the allocation assigned to each record as displayed in the record view.
                 Given I click on the link labeled "Data Exports, Reports, and Stats"
@@ -107,7 +134,7 @@ Feature: C.3.30.1500.	User Interface: The system shall support blinded and open 
                 Given I login to REDCap with the user "Test_User1"
                 And I click on the link labeled "Setup"
                 And I click on the button labeled "Set up randomization"
-                And I click on the icon in the column labeled "Setup" and the row labeled "strat_1"
+                And I click on the icon in the column labeled "Setup" and the row labeled "rand_group"
                 Then I should see "STEP 3: Upload your allocation table (CSV file)"
                 When I click on the button labeled "Download table"
                 Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"
@@ -138,7 +165,7 @@ Feature: C.3.30.1500.	User Interface: The system shall support blinded and open 
                 Given I login to REDCap with the user "Test_Admin"
                 And I click on the link labeled "Setup"
                 And I click on the button labeled "Set up randomization"
-                And I click on the icon in the column labeled "Setup" and the row labeled "strat_1"
+                And I click on the icon in the column labeled "Setup" and the row labeled "rand_group"
                 Then I should see "STEP 3: Upload your allocation table (CSV file)"
                 When I click on the button labeled "Download table"
                 Then I should see a downloaded file named "RandomizationAllocationTable_Dev.csv"

--- a/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1500. - Randomization blind.feature
@@ -29,7 +29,7 @@ Feature: C.3.30.1500.	User Interface: The system shall support blinded and open 
                 And I click on the button labeled "Add new randomization model"
                 And I check the checkbox labeled "A) Use stratified randomization?"
                 And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-                And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
+                And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
                 And I click on the button labeled "Save randomization model"
                 Then I should see "Success! The randomization model has been saved!"
                 When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file

--- a/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
@@ -1,85 +1,82 @@
 Feature: C.3.30.1600.	User Interface: The system shall ensure users with randomization dashboard rights can view the randomization dashboard.	
-As a REDCap end user
-I want to see that Randomization is functioning as expected
+        As a REDCap end user
+        I want to see that Randomization is functioning as expected
 
-Scenario: #SETUP project with randomization enabled
-    Given I login to REDCap with the user "Test_User1"
-    And I create a new project named "C.3.30.1600." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
-    
-    #Adding user rights Test_User1 (with randomize rights)
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
-    And I click on the button labeled "Assign to role"
-    And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
-    When I click on the button labeled "Assign"
-    Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
-      
-    #Adding user Test_User2 (without randomize rights)
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User2" into the field with the placeholder text of "Add new user"
-    And I click on the button labeled "Add with custom rights"
-    And I click on the checkbox labeled "Project Design and Setup"
-    And I check the checkbox labeled "Setup"
-    And I uncheck the checkbox labeled "Dashboard"
-    And I click on the button labeled "Add user"
-    Then I should see 'User "Test_User2" was successfully added'
-    And I should see a table header and rows containing the following values in a table:
-            | Role name               | Username            | Randomization |
-            | —                       | test_user2          | Setup Randomize |
+        Scenario: #SETUP project with randomization enabled
+                Given I login to REDCap with the user "Test_User1"
+                And I create a new project named "C.3.30.1600." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
 
-    #SETUP Creating randomiztion stategy and adding allocation table.
-    When I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the button labeled "Add new randomization model"
-    And I check the checkbox labeled "A) Use stratified randomization?"
-    And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
-    And I click on the button labeled "Save randomization model"
-    Then I should see "Success! The randomization model has been saved!"
-    
-    #Adding valid allocation table
-    When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
-    Then I should see "Already uploaded"
+                #Adding user rights Test_User1 (with randomize rights)
+                When I click on the link labeled "User Rights"
+                And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
+                And I click on the button labeled "Assign to role"
+                And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
+                When I click on the button labeled "Assign"
+                Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
 
-    #Adding record with randomization
-    And I click on the link labeled "Add / Edit Records"
-    And I select "2" on the dropdown field labeled "Choose an existing Record ID"
-    And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
-    And I select the radio option "Yes" for the field labeled "Stratification 1"
-    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-    Then I should see "Record ID 2 successfully edited."
-    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    And I click on the button labeled "Randomize" 
-    Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
-    And I click on the button labeled "Randomize"
-    Then I should see "was randomized for"
-    And I click on the button labeled "Close"
-    And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
-    Then I should see "Record ID 2 successfully edited."
+                #Adding user Test_User2 (without randomize rights)
+                When I click on the link labeled "User Rights"
+                And I enter "Test_User2" into the field with the placeholder text of "Add new user"
+                And I click on the button labeled "Add with custom rights"
+                And I click on the checkbox labeled "Project Design and Setup"
+                And I check the checkbox labeled "Setup"
+                And I uncheck the checkbox labeled "Dashboard"
+                And I click on the button labeled "Add user"
+                Then I should see 'User "Test_User2" was successfully added'
+                And I should see a table header and rows containing the following values in a table:
+                        | Role name               | Username            | Randomization   |
+                        | —                       | test_user2          | Setup Randomize |
 
-Scenario: #C.3.30.1600.0200 ensures that access is granted when the user has the correct dashboard rights. 
-    Given I login to REDCap with the user "Test_User1"
-    And I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.1600."
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
-    Then I should see a table header and rows containing the following values in a table:
-            |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
-            |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
-            |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        | 
+                #SETUP Creating randomiztion stategy and adding allocation table.
+                When I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the button labeled "Add new randomization model"
+                And I check the checkbox labeled "A) Use stratified randomization?"
+                And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
+                And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
+                And I click on the button labeled "Save randomization model"
+                Then I should see "Success! The randomization model has been saved!"
 
-Scenario: #C.3.30.1600.0100 ensures that access is denied when the user lacks the appropriate permission.
-    Given I login to REDCap with the user "Test_User2"
-    And I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.1600."
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    Then I should see a table header and rows containing the following values in a table:
-            | #      | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Randomization ID |
-            | 1      | rand_group |                 | strat_1        | 2                              | 0                           |       | 2                |
-    
-    And I should NOT see a button labeled "Dashboard"
+                #Adding valid allocation table
+                When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
+                Then I should see "Already uploaded"
 
-    #Given I logout
-  #End
+                #Adding record with randomization
+                And I click on the link labeled "Add / Edit Records"
+                And I select "2" on the dropdown field labeled "Choose an existing Record ID"
+                And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
+                And I select the radio option "Yes" for the field labeled "Stratification 1"
+                And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+                Then I should see "Record ID 2 successfully edited."
+                And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+                And I click on the button labeled "Randomize"
+                Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
+                And I click on the button labeled "Randomize"
+                Then I should see "was randomized for"
+                And I click on the button labeled "Close"
+                And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
+                Then I should see "Record ID 2 successfully edited."
+
+        Scenario: #C.3.30.1600.0200 ensures that access is granted when the user has the correct dashboard rights.
+                Given I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
+                Then I should see a table header and rows containing the following values in a table:
+                        |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
+                        |       | 0       |     1    |                   | No (0)           | Drug B (2)        |
+                        |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        |
+                And I logout
+
+        Scenario: #C.3.30.1600.0100 ensures that access is denied when the user lacks the appropriate permission.
+                Given I login to REDCap with the user "Test_User2"
+                And I click on the link labeled "My Projects"
+                And I click on the link labeled "C.3.30.1600."
+                And I click on the link labeled "Setup"
+                And I click on the button labeled "Set up randomization"
+                Then I should see a table header and rows containing the following values in a table:
+                        | #      | Target     | Allocation Type | Stratification | Total Allocations (Development) |Total Allocations (Production)| Setup | Randomization ID |
+                        | 1      | rand_group |                 | strat_1        | 2                               | 0                            |       | 2                |
+
+                And I should NOT see a table with header "Dashboard"
+                Given I logout
+#End

--- a/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1600. - Randomization view dashboard.feature
@@ -33,7 +33,7 @@ Feature: C.3.30.1600.	User Interface: The system shall ensure users with randomi
                 And I click on the button labeled "Add new randomization model"
                 And I check the checkbox labeled "A) Use stratified randomization?"
                 And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-                And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
+                And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
                 And I click on the button labeled "Save randomization model"
                 Then I should see "Success! The randomization model has been saved!"
 

--- a/Feature Tests/C/Randomization_30/C.3.30.1700. - Randomization view allocation.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1700. - Randomization view allocation.feature
@@ -1,8 +1,8 @@
 Feature: Project Interface Administrator Access: The system shall support administrator-only access to the randomization module's View Allocation Table page.
-As a REDCap end user
-I want to see that Randomization is functioning as expected
+  As a REDCap end user
+  I want to see that Randomization is functioning as expected
   
-   Scenario: #SETUP project with randomization enabled
+  Scenario: #SETUP project with randomization enabled
     Given I login to REDCap with the user "Test_User1"
     And I create a new project named "C.3.30.1700." by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
     
@@ -14,14 +14,6 @@ I want to see that Randomization is functioning as expected
     When I click on the button labeled "Assign"
     Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
       
-    #Adding user Test_User2 (No randomization rights)
-    When I click on the link labeled "User Rights"
-    And I enter "Test_User2" into the field with the placeholder text of "Add new user"
-    And I click on the button labeled "Add with custom rights"
-    And I click on the checkbox labeled "Project Design and Setup"
-    And I click on the button labeled "Add user"
-    Then I should see 'User "Test_User2" was successfully added'
-    
     #SETUP Creating randomiztion stategy and adding allocation table.
     When I click on the link labeled "Setup"
     And I click on the button labeled "Set up randomization"
@@ -36,7 +28,7 @@ I want to see that Randomization is functioning as expected
     When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
     Then I should see "Already uploaded"
 
-    # Create Record for one stratum
+    #Create Record for one stratum
     When I click on the link labeled "Add / Edit Records"
     And I select "1" on the dropdown field labeled "Choose an existing Record ID"
     And I click the bubble for the row labeled "Demographics" on the column labeled "Status"
@@ -53,44 +45,24 @@ I want to see that Randomization is functioning as expected
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 1 successfully edited."
 
- Scenario:#C.3.30.1700.0100. Admin accesses View Allocation Table page.  
-    Given I click on the link labeled "Randomization"
+    When  I click on the link labeled "Randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     Then I should see a table header and rows containing the following values in a table:
-            |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
-            |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
-	          |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        | 
-     
-    
-    #VERIFY Non project Admin can not see Allocation Table page from the Dashboard.
-    Given I logout
-    And I login to REDCap with the user "Test_User2"
-    When I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.1700."
-    And I click on the link labeled "Setup"
-    Then I should see a button labeled "Set up randomization" that is disabled
+      |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
+      |       | 0       |     1    |                   | No (0)           | Drug B (2)        |
+      |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        |
+    #C.3.30.1700.0200. User with dashboard rights cannot access View Allocation Table. 
+    And I should NOT see a table with header "View"
     And I logout
 
- Scenario:#C.3.30.1700.0200. User with dashboard rights cannot access View Allocation Table.
-    #SETUP to modify user rights for test
-    Given I login to REDCap with the user "Test_User1"
-    And I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.1700."
-    And I click on the link labeled "User Rights"
-    And I click on the link labeled "Test User2"
-    And I click on the button labeled "Edit user privileges"
-    And I check the checkbox labeled "Dashboard"
-    And I uncheck the checkbox labeled "Randomize"
-    And I click on the button labeled "Save Changes"
-    Then I should see 'User "test_user2" was successfully edited' 
-    And I logout
-
-    When I login to REDCap with the user "Test_User2"
-    And I click on the link labeled "My Projects"
-    And I click on the link labeled "C.3.30.1700."
-    And I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization"
-    #VERIFY Test User with dashboard permissions cannot see Allocation Table
-    Then I should NOT see the button labeled "Setup"
-
+  Scenario: #C.3.30.1700.0100. Admin accesses View Allocation Table page.
+    Given I login to REDCap with the user "Test_Admin"
+    When  I click on the link labeled "Randomization"
+    And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
+    Then I should see a table header and rows containing the following values in a table:
+      |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group| View |
+      |       | 0       |     1    |                   | No (0)           | Drug B (2)        |      |
+      |       | 1       |     0    |     1             | Yes (1)          | Drug A (1)        |      |
+    When I click on the icon in the column labeled "View" and the row labeled "Drug B"
+    Then I should see "View Allocation Table"
 #End

--- a/Feature Tests/C/Randomization_30/C.3.30.1800. - Randomization Admin actions.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1800. - Randomization Admin actions.feature
@@ -20,7 +20,7 @@ Feature: Project Interface Administrator Access: The system shall support the ad
     And I click on the button labeled "Add new randomization model"
     And I check the checkbox labeled "A) Use stratified randomization?"
     And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
+    And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
     And I click on the button labeled "Save randomization model"
     Then I should see "Success! The randomization model has been saved!"
 

--- a/Feature Tests/C/Randomization_30/C.3.30.1800. - Randomization Admin actions.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1800. - Randomization Admin actions.feature
@@ -2,10 +2,10 @@ Feature: Project Interface Administrator Access: The system shall support the ad
   As a REDCap end user
   I want to see that Randomization is functioning as expected
 
- Scenario: #SETUP - Create new project
+  Scenario: #SETUP - Create new project
     Given I login to REDCap with the user "Test_User1"
     And I create a new project named "C.3.30.1800" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project 3.30 baserand.REDCap.xml", and clicking the "Create Project" button
-    
+
     #Adding user rights Test_User1 (with randomize rights)
     When I click on the link labeled "User Rights"
     And I enter "Test_User1" into the field with the placeholder text of "Assign new user to role"
@@ -13,17 +13,17 @@ Feature: Project Interface Administrator Access: The system shall support the ad
     And I select "1_FullRights" on the dropdown field labeled "Select Role" on the role selector dropdown
     When I click on the button labeled "Assign"
     Then I should see "test_user1" within the "1_FullRights" row of the column labeled "Username" of the User Rights table
-       
+
     #SETUP Creating randomiztion stategy and adding allocation table.
     When I click on the link labeled "Setup"
     And I click on the button labeled "Set up randomization"
     And I click on the button labeled "Add new randomization model"
     And I check the checkbox labeled "A) Use stratified randomization?"
     And I select "strat_1 (Stratification 1)" on the first dropdown field labeled "- select a field -"
-    And I select "rand_group (Randomization group 1)" on the dropdown field labeled "Choose your randomization field"
+    And I select "rand_group (Randomization group 1)" on the second dropdown field labeled "- select a field -"
     And I click on the button labeled "Save randomization model"
     Then I should see "Success! The randomization model has been saved!"
-    
+
     #Adding valid allocation table
     When I upload a "csv" format file located at "import_files/Randomization_one_strat.csv", by clicking the button near "for use in DEVELOPMENT status" to browse for the file, and clicking the button labeled "Upload" to upload the file
     Then I should see "Already uploaded"
@@ -36,7 +36,7 @@ Feature: Project Interface Administrator Access: The system shall support the ad
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 2 successfully edited."
     And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    And I click on the button labeled "Randomize" 
+    And I click on the button labeled "Randomize"
     Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
     And I click on the button labeled "Randomize"
     Then I should see "was randomized for"
@@ -51,17 +51,21 @@ Feature: Project Interface Administrator Access: The system shall support the ad
     And I select the radio option "No" for the field labeled "Stratification 1"
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 3 successfully edited."
-   
- Scenario:#C.3.30.1800.0100. Admin can edit target field with reason.  
+
+  Scenario:#C.3.30.1800.0100. Admin can edit target field with reason.
     Given I login to REDCap with the user "Test_Admin"
     And I click on the link labeled "Randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     Then I should see a table header and rows containing the following values in a table:
-            |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
-            |       | 0       |     1    |                   | No (0)           | Drug B (2)        |   
-	          |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        | 
+      |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
+      |       | 0       |     1    |                   | No (0)           | Drug B (2)        |
+      |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        |
     And I click on the icon in the column labeled "View" and the row labeled "Drug B"
     Then I should see "View Allocation Table"
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 2            |           |        |      |
+    And I should see a "2" within the "1" row of the column labeled "Target Field"
 
     When I click on the icon labeled "Edit Target Field"
     Then I should see "Specify Reason"
@@ -73,28 +77,31 @@ Feature: Project Interface Administrator Access: The system shall support the ad
     And I enter "CONFIRM" into the input field labeled 'Type "CONFIRM"'
     And I click on the button labeled "Confirm"
     Then I should see a "3" within the "1" row of the column labeled "Target Field"
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 3            |           |        |      |
 
     #VERIFY that the change to the target is reflected in the randomization dashboard
     When I click on the link labeled "Dashboard"
     Then I should see a table header and rows containing the following values in a table:
-            |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
-            |       | 0       |     1    |                   | No (0)           | Placebo (3)        |   
-	          |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        | 
+      |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group |
+      |       | 0       |     1    |                   | No (0)           | Placebo (3)        |
+      |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)         |
 
-     #VERIFY: Logging
+    #VERIFY: Logging
     Given I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
       | Username   | Action        | List of Data Changes OR Fields Exported      |
       | test_admin | Manage/Design | Update randomization allocation table (development) (aid: 2, target_field: "3", reason: "Test reason")|
 
-Scenario: #C.3.30.1800.0200. Admin can edit target alternative with reason. 
+  Scenario: #C.3.30.1800.0200. Admin can edit target alternative with reason.
     Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization" 
+    And I click on the button labeled "Set up randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     And I click on the icon in the column labeled "View" and the row labeled "Placebo"
     Then I should see "View Allocation Table"
-
-    When I click on the icon labeled "Edit Target Alternate"  
+    And I should see a " " within the "1" row of the column labeled "Alternate"
+    When I click on the icon labeled "Edit Target Alternate"
     Then I should see "Specify Reason"
     And I should see "Enter new value"
     And I should see 'Type "CONFIRM"'
@@ -104,37 +111,58 @@ Scenario: #C.3.30.1800.0200. Admin can edit target alternative with reason.
     And I enter "CONFIRM" into the input field labeled 'Type "CONFIRM"'
     And I click on the button labeled "Confirm"
     Then I should see a "1" within the "1" row of the column labeled "Alternate"
-
-     #VERIFY: Logging
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 3            | 1         |        |      |
+    #VERIFY: Logging
     Given I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
       | Username   | Action        | List of Data Changes OR Fields Exported      |
       | test_admin | Manage/Design | Update randomization allocation table (development) (aid: 2, target_field_alt: "1", reason: "Test reason")|
 
-    #VERIFY manually that the change to the alternate is reflected in the Randomization Allocation Table
-    #Given I click on the link labeled "Project Setup"
-    #And I click on the button labeled "Set up randomization"
-    #And I click on the icon labeled "Setup" in the row labeled "2"
-    #And I click on the button "Download table" near "Upload allocation table (CSV file) for use in DEVELOPMENT status"
-    #Note to Automated test editor:  Is there a way to check the csv file for the following?  If not possible, then we could perhaps drop line 121-128.
-    #Download allocation table - "1" should appear in the redcap_randomization number column for row 4 in the csv file and "3" in the redcap_randomization_group column for row 4.
+    Given I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
+    And I click on the icon in the column labeled "Setup" and the row labeled "1"
+    And I click on the button labeled "Download table"
+    Then I should see the latest downloaded "csv" file containing the headings and rows below
+      | redcap_randomization_number | redcap_randomization_group | strat_1 |
+      |                             | 1                          | 1       |
+      | 1                           | 3                          | 0       |
 
-Scenario: #C.3.30.1800.0300. Admin can manually randomize a record with reason. 
-    Given I click on the link labeled "Randomization"
+  Scenario: #C.3.30.1800.0300. Admin can manually randomize a record with reason.
+    #VERIFY record is not randomized.
+    When I click on the link labeled "Add / Edit Records"
+    And I select "3" on the dropdown field labeled "Choose an existing Record ID"
+    And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
+    Then I should see a button labeled "Randomize"
+    And I should NOT see "Already randomized"
+
+    Given I click on the link labeled "Setup"
+    And I click on the button labeled "Set up randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     And I click on the icon in the column labeled "View" and the row labeled "Placebo"
     Then I should see "View Allocation Table"
+    And I should see a "" within the "1" row of the column labeled "Record"
 
-    When I click on the icon labeled "Manual Randomization"  
+    When I click on the icon labeled "Manual Randomization"
     Then I should see "Specify Reason"
     And I should see "Existing record to assign"
     And I should see 'Type "CONFIRM"'
 
     When I enter "Test reason" into the input field labeled "Specify Reason"
     And I enter "3" into the input field labeled "Existing record to assign"
-    And I enter "CONFIRM" into the input field labeled 'Type "CONFIRM"' in the dialog box 
+    And I enter "CONFIRM" into the input field labeled 'Type "CONFIRM"'
     And I click on the button labeled "Confirm"
     Then I should see a "3" within the "1" row of the column labeled "Record"
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 3            | 1         | 3      |      |
+
+    When I click on the link labeled "Dashboard"
+    Then I should see a table header and rows containing the following values in a table:
+      |       | Used    | Not Used | Allocated records | Stratification 1 |Randomization group|
+      |       | 1       |     0    |     2             | Yes (1)          | Drug A (1)        |
+      |       | 1       |     0    |     3             | No (0)           | Placebo (3)       |
 
     #VERIFY: Logging
     Given I click on the link labeled "Logging"
@@ -147,16 +175,21 @@ Scenario: #C.3.30.1800.0300. Admin can manually randomize a record with reason.
     And I select "3" on the dropdown field labeled "Choose an existing Record ID"
     And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
     Then I should see "Already randomized"
-    And I should see a radio labeled "Placebo" that is disabled 
+    And I should NOT see a button labeled "Randomized"
+    And I should see a radio labeled "Placebo" in the row labeled "Randomization group 1" that is disabled
+    And I should see the radio labeled "Randomization group 1" with option "Placebo" selected
 
-Scenario: #C.3.30.1800.0600. Admin can remove randomization with reason.
+  Scenario: #C.3.30.1800.0600. Admin can remove randomization with reason.
     Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization" 
+    And I click on the button labeled "Set up randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     And I click on the icon in the column labeled "View" and the row labeled "Drug A"
     Then I should see "View Allocation Table"
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 1            |           | 2      |      |
 
-    When I click on the icon labeled "Remove Randomization"  
+    When I click on the icon labeled "Remove Randomization"
     Then I should see "Remove Randomization"
     And I should see "Specify Reason"
     And I should see 'Type "CONFIRM"'
@@ -169,23 +202,26 @@ Scenario: #C.3.30.1800.0600. Admin can remove randomization with reason.
     And I should see an icon labeled "Edit Target Alternate" in the row labeled "1"
     And I should see an icon labeled "Manual Randomization" in the row labeled "1"
     And I should see an icon labeled "Make Sequence Unavailable" in the row labeled "1"
-  
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 1            |           |        |      |
+
     #VERIFY: Logging
     Given I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
       | Username   | Action        | List of Data Changes OR Fields Exported      |
       | test_admin | Manage/Design | Update randomization allocation table (development) - Remove randomization (aid: 1, is_used_by: "", reason: "Test reason")|
       | test_admin | Update record 2 | rand_group = ''|
-              
+
     #VERIFY record 2 is now not randomized
     Given I click on the link labeled "Add / Edit Records"
     And I select "2" on the dropdown field labeled "Choose an existing Record ID"
     And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    Then I should see a button labeled "Randomize"     
+    Then I should see a button labeled "Randomize"
 
-Scenario: #C.3.30.1800.0400. Admin can mark a sequence as unavailable with reason. 
+  Scenario: #C.3.30.1800.0400. Admin can mark a sequence as unavailable with reason.
     Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization" 
+    And I click on the button labeled "Set up randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     And I click on the icon in the column labeled "View" and the row labeled "Drug A"
     Then I should see "View Allocation Table"
@@ -200,6 +236,9 @@ Scenario: #C.3.30.1800.0400. Admin can mark a sequence as unavailable with reaso
     And I click on the button labeled "Confirm"
     Then I should see a "" within the "1" row of the column labeled "Record"
     And I should see an icon labeled "Restore" in the row labeled "1"
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 1            |           |        |      |
 
     #VERIFY: Logging
     Given I click on the link labeled "Logging"
@@ -212,7 +251,7 @@ Scenario: #C.3.30.1800.0400. Admin can mark a sequence as unavailable with reaso
     Given I click on the link labeled "Add / Edit Records"
     And I select "2" on the dropdown field labeled "Choose an existing Record ID"
     And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    And I click on the button labeled "Randomize" 
+    And I click on the button labeled "Randomize"
     Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
     And I click on the button labeled "Randomize"
     Then I should see "RANDOMIZATION ERROR"
@@ -221,9 +260,9 @@ Scenario: #C.3.30.1800.0400. Admin can mark a sequence as unavailable with reaso
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 2 successfully edited."
 
-Scenario: #C.3.30.1800.0500. Admin can restore allocation with reason.
+  Scenario: #C.3.30.1800.0500. Admin can restore allocation with reason.
     Given I click on the link labeled "Setup"
-    And I click on the button labeled "Set up randomization" 
+    And I click on the button labeled "Set up randomization"
     And I click on the icon in the column labeled "Dashboard" and the row labeled "1"
     And I click on the icon in the column labeled "View" and the row labeled "Drug A"
     Then I should see "View Allocation Table"
@@ -241,6 +280,9 @@ Scenario: #C.3.30.1800.0500. Admin can restore allocation with reason.
     And I should see an icon labeled "Edit Target Alternate" in the row labeled "1"
     And I should see an icon labeled "Manual Randomization" in the row labeled "1"
     And I should see an icon labeled "Make Sequence Unavailable" in the row labeled "1"
+    And I should see a table header and rows containing the following values in a table:
+      | Sequence | Target Field | Alternate | Record | Edit |
+      |  1       | 1            |           |        |      |
 
     #VERIFY: Logging
     Given I click on the link labeled "Logging"
@@ -252,13 +294,13 @@ Scenario: #C.3.30.1800.0500. Admin can restore allocation with reason.
     Given I click on the link labeled "Add / Edit Records"
     And I select "2" on the dropdown field labeled "Choose an existing Record ID"
     And I click the bubble for the row labeled "Randomization" on the column labeled "Status"
-    And I click on the button labeled "Randomize" 
+    And I click on the button labeled "Randomize"
     Then I should see a dialog containing the following text: "Below you may perform randomization for Record ID"
     And I click on the button labeled "Randomize"
     Then I should see "was randomized for"
     And I click on the button labeled "Close"
     And I select the submit option labeled "Save & Exit Form" on the Data Collection Instrument
     Then I should see "Record ID 2 successfully edited."
-    
+
     Given I logout
- #END
+#END


### PR DESCRIPTION
- C.3.30.0200. - Randomization project enable - Deleted duplicate steps and modified user rights verification.
- C.3.30.0300. - Randomization rights setup - Added new script. This was previously labeled as REDUNDANT but was not properly tested.
- C.3.30.0400. - REDUNDANT.Randomization rights dashboard - is this needed? It's same as C.3.30.1600. - Randomization view dashboard
- C.3.30.0500. - Randomization rights randomize - is this needed? same as C.3.30.1100. - Randomization rights execute
- C.3.30.0600. - Randomization DAG. - Modified. Added DAG 2 randomization verification.
- C.3.30.0700. - Randomization create - Modified script. Deleted lots of steps as not required. Last few scenarios are tested in C.3.30.0900.
- C.3.30.1000. - Randomization assignment - Commented out duplicate steps to avoid redundancy
- C.3.30.1500. - Randomization blind - Modified script to add some checks and rewritten the steps to reduce redundancy.
- C.3.30.1600. - Randomization view dashboard - Modified- I should NOT see a button labeled "Dashboard" is not correct.- Added New SD - And I should NOT see a table with header "Dashboard"
- C.3.30.1700. - Randomization view allocation - Modified script as it was not testing the feature correctly.
- C.3.30.1800. - Randomization Admin actions.feature - Modified script as it was not verying tests properly
- There are also other scripts which have minor changes.