### PR TITLE
Adding a manual step to CDIS tests.

### DIFF
--- a/Feature Tests/C/CDIS_31/C.3.31.0100. - Enabling and Disabling Clinical Data Pull.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0100. - Enabling and Disabling Clinical Data Pull.feature
@@ -18,7 +18,8 @@ Feature: C.3.31.0100. Control Center- The system shall support enabling and disa
         And I select "No, hide all information about CDP" on the dropdown field labeled "Display information about CDP on Project Setup page in a project?"
         And I click on the button labeled "Save Changes"
 
-     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+     #SET UP SMARTHEALTH IT IN CONTROL CENTER
+     #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.0200. - Enabling and Disabing Clinical Data Mart CDM.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0200. - Enabling and Disabing Clinical Data Mart CDM.feature
@@ -16,6 +16,7 @@ When I select "Enabled" on the dropdown field labeled "Clinical Data Mart"
 And I click on the button labeled "Save Changes"
 
 #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+#M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
 When I click on the link labeled "FHIR Systems"
 Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
 When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.0300. - Enable and Disable Instant Adjudication for CDP.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0300. - Enable and Disable Instant Adjudication for CDP.feature
@@ -18,7 +18,8 @@ Feature: C.3.31.0300. Control Center: The system shall support enabling and disa
         And I select "No, hide all information about CDP" on the dropdown field labeled "Display information about CDP on Project Setup page in a project?"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.0400. - Enable and Disable Break the glass for CDP.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0400. - Enable and Disable Break the glass for CDP.feature
@@ -19,6 +19,7 @@ Feature: C.3.31.0400. Control Center: The system shall support enabling and disa
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.0500. - Displaying information about CDP on Project Setup page.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0500. - Displaying information about CDP on Project Setup page.feature
@@ -12,6 +12,7 @@ When I select "Enable" on the dropdown field labeled "Clinical Data Pull"
 And I click on the button labeled "Save Changes"
 
 #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+#M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
 When I click on the link labeled "FHIR Systems"
 Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
 When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.0600. - The system shall support configuring user rights to assign or restrict Clinical Data Pull CDP privileges within a project.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0600. - The system shall support configuring user rights to assign or restrict Clinical Data Pull CDP privileges within a project.feature
@@ -19,7 +19,8 @@ Given I login to REDCap with the user "Test_Admin"
     And I select "No, hide all information about CDP" on the dropdown field labeled "Display information about CDP on Project Setup page in a project?"
     And I click on the button labeled "Save Changes"    
 
-#SET UP SMARTHEALTH IT IN CONTROL CENTER 
+#SET UP SMARTHEALTH IT IN CONTROL CENTER
+#M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
     When I click on the link labeled "FHIR Systems"
     Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
     When I click on the button labeled "Add"
@@ -36,7 +37,8 @@ Given I login to REDCap with the user "Test_Admin"
     Then I should see "New FHIR system created"
     And I click on the link labeled "Home"
     And I logout
-
+    
+#Project Creation
     Given I login to REDCap with the user "Test_Admin"
     And I create a new project named "C.3.31.0600" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_7.31.xml", and clicking the "Create Project" button
     And I click on the link labeled "My Projects"

--- a/Feature Tests/C/CDIS_31/C.3.31.0800. - Allowing or restricting the import of patient email addresses.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0800. - Allowing or restricting the import of patient email addresses.feature
@@ -12,7 +12,8 @@ Feature: C.3.31.0800. Control Center: The system shall support allowing or restr
         And I select "No, do not display 'email address' option in EHR source field list" on the dropdown field labeled "Allow the patient's email address to be imported from the EHR?"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required.  
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.0900. - The system shall support displaying custom instructions or institution-specific requirements for enabling CDP, including HTML formatting.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0900. - The system shall support displaying custom instructions or institution-specific requirements for enabling CDP, including HTML formatting.feature
@@ -18,6 +18,7 @@ Feature: C.3.31.0900. Control Center: The system shall support displaying custom
         And I click on the button labeled "Save Changes"
 
      #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+     #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.1100. - Enabling CDP in a project.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.1100. - Enabling CDP in a project.feature
@@ -18,6 +18,7 @@ Feature: C.3.31.1100. Project Setup: The system shall support enabling and disab
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.1200. - Allowing or restricting the import of patient email addresses into CDP.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.1200. - Allowing or restricting the import of patient email addresses into CDP.feature
@@ -13,6 +13,7 @@ Feature: C.3.31.1200. Control Center: The system shall support allowing or restr
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.1400. - Allowing or restricting the import of patient email addresses into CDM.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.1400. - Allowing or restricting the import of patient email addresses into CDM.feature
@@ -14,6 +14,7 @@ Feature: C.3.31.1400. Control Center: The system shall support allowing or restr
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.1500. - Setting CDP user rights in a project.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.1500. - Setting CDP user rights in a project.feature
@@ -18,6 +18,7 @@ Feature: C.3.31.1500. Project Setup: The system shall support assigning user pri
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.1700. - Mapping REDCap fields to EHR source fields.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.1700. - Mapping REDCap fields to EHR source fields.feature
@@ -13,7 +13,8 @@ Feature: C.3.31.1700. User Interface: The system shall support mapping REDCap fi
       And I click on the button labeled "Save Changes"
       Then I should see "Loading"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
       When I click on the link labeled "FHIR Systems"
       Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
       When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.1800. - The system shall support defining day offsets for temporal field.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.1800. - The system shall support defining day offsets for temporal field.feature
@@ -12,6 +12,7 @@ Feature: C.3.31.1800. User Interface: The system shall support defining day offs
       Then I should see "Loading"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
       When I click on the link labeled "FHIR Systems"
       Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
       When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.1900. - Limiting temporal data fetch to records with dates.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.1900. - Limiting temporal data fetch to records with dates.feature
@@ -12,6 +12,7 @@ Feature: C.3.31.1900. User Interface: The system shall support limiting the fetc
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2000. - The system shall support fetching data from the EHR and displaying values in the adjudication interface.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2000. - The system shall support fetching data from the EHR and displaying values in the adjudication interface.feature
@@ -12,6 +12,7 @@ Feature: C.3.31.2000. User Interface: The system shall support fetching data fro
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2100. - Adjudicates and selects values in the CDP adjudication interface.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2100. - Adjudicates and selects values in the CDP adjudication interface.feature
@@ -12,6 +12,7 @@ Feature: C.3.31.2100. User Interface: The system shall support importing EHR dat
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2200. - The system shall support optional preview fields on the CDP mapping page.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2200. - The system shall support optional preview fields on the CDP mapping page.feature
@@ -11,7 +11,8 @@ Feature: C.3.31.2200. User Interface: The system shall support optional preview 
         When I select "Enable" on the dropdown field labeled "Clinical Data Pull"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2300. - The system shall support up to five preview fields per CDP-enabled project.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2300. - The system shall support up to five preview fields per CDP-enabled project.feature
@@ -19,6 +19,7 @@ Feature: C.3.31.2300. User Interface: The system shall support up to five previe
         And I should NOT see "Loading"
 
      #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+     #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2500. - The system shall support adjudication of source data.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2500. - The system shall support adjudication of source data.feature
@@ -17,6 +17,7 @@ Feature: C.3.31.2500. User Interface: The system shall support adjudication of s
         And I should NOT see "Loading"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2600. - Count of new unadjudicated values.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2600. - Count of new unadjudicated values.feature
@@ -17,7 +17,8 @@ Feature: C.3.31.2600. User Interface: The system shall support displaying a coun
         And I enter "1" into the input field labeled "Time interval that REDCap will check the source system for new data for individual records"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2800. - The system shall support importing and exporting CDP mapping configurations.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2800. - The system shall support importing and exporting CDP mapping configurations.feature
@@ -17,7 +17,8 @@ Feature: C.3.31.2800. User Interface: The system shall support importing and exp
         And I select "No, hide all information about CDP" on the dropdown field labeled "Display information about CDP on Project Setup page in a project?"
         And I click on the button labeled "Save Changes"
 
-     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+     #SET UP SMARTHEALTH IT IN CONTROL CENTER
+     #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.2900. - CDP Mapping Helper tool.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.2900. - CDP Mapping Helper tool.feature
@@ -18,6 +18,7 @@ Feature: C.3.31.2900. User Interface: The system shall support using the CDP Map
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.3100. - Automatic project creation of new CDM project.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.3100. - Automatic project creation of new CDM project.feature
@@ -14,6 +14,7 @@ As a REDCap end user I want to see that when a user creates a CDM project the pr
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.3200. - Fetching data in bulk via CDM.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.3200. - Fetching data in bulk via CDM.feature
@@ -14,6 +14,7 @@ Feature: C.3.31.3200. User Interface: The system shall support fetching clinical
         And I click on the button labeled "Save Changes"
 
     #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.3300. - Fetching data in bulk via CDM with date restrictions.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.3300. - Fetching data in bulk via CDM with date restrictions.feature
@@ -13,7 +13,8 @@ Scenario: Setup
         And I select "No, do not display 'email address' option in EHR source field list" on the dropdown field labeled "Allow the patient's email address to be imported from the EHR?"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.3500. - Multiple bulk fetches of clinical data.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.3500. - Multiple bulk fetches of clinical data.feature
@@ -13,7 +13,8 @@ As a REDCap end user I want to see that a user can fetch data in bulk more than 
         And I select "No, do not display 'email address' option in EHR source field list" on the dropdown field labeled "Allow the patient's email address to be imported from the EHR?"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.3700. - Reqesting a configuration update to a CDM fetch request.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.3700. - Reqesting a configuration update to a CDM fetch request.feature
@@ -13,7 +13,8 @@ Feature: C.3.31.3700. User Interface: The system shall support the ability to re
         And I select "No, do not display 'email address' option in EHR source field list" on the dropdown field labeled "Allow the patient's email address to be imported from the EHR?"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"

--- a/Feature Tests/C/CDIS_31/C.3.31.3800. - Auto-Fetch for CDP and CDM enabled projects.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.3800. - Auto-Fetch for CDP and CDM enabled projects.feature
@@ -14,7 +14,8 @@ Scenario: Setup
         And I enter "1" into the input field labeled "Every"
         And I click on the button labeled "Save Changes"
 
-    #SET UP SMARTHEALTH IT IN CONTROL CENTER 
+    #SET UP SMARTHEALTH IT IN CONTROL CENTER
+    #M Only one FHIR system setup is needed to test the functionality. You can skip these steps if you have already done this on another CDIS test. These FHIR settings will allow for validation against smart health IT and ensure REDCap can pull data via FHIR. If you want to validate against your local EHR vendor modification to these steps will be required. 
         When I click on the link labeled "FHIR Systems"
         Then I should see "This interface enables the connection of REDCap with multiple FHIR (Fast Healthcare Interoperability Resources) systems. FHIR is a standard for electronic healthcare information exchange, while SMART on FHIR provides specifications for integrating apps with Electronic Health Records using FHIR standards and OAuth2 security."
         When I click on the button labeled "Add"


### PR DESCRIPTION
This PR is to add clarity for anyone doing manual validation. When doing manual validation the FHIR configuration steps do not need to be completed before each test, this is solely for automation. Doing this would actually have an inverse reaction to the testing outcomes. Because of this it was decided to add a clarifying step into the scripts.