### PR TITLE
Removed extra steps that were causing intermittent cloud failures

### DIFF
--- a/Feature Tests/C/CDIS_31/C.3.31.0500. - Displaying information about CDP on Project Setup page.feature
+++ b/Feature Tests/C/CDIS_31/C.3.31.0500. - Displaying information about CDP on Project Setup page.feature
@@ -36,11 +36,6 @@ And I click on the link labeled "My Projects"
 And I click on the link labeled "C.3.31.0500"
 
 ##ACTION Enable CDP in Project
- When I click on the button labeled "Enable" in the row labeled "SendGrid Template email services for Alerts & Notifications"
-# And I click on the button labeled "Enable" in the "SendGrid Template email services for Alerts & Notifications" row in the "Enable optional modules and customizations" section
-# And I click on the button labeled "Enable" in the "SendGrid Template email services for Alerts & Notifications" row in the "Enable optional modules and customizations" section
-And I select "Enable" on the dropdown field labeled "SendGrid Template Email Services"
-And I click on the button labeled "Save"
 And I click on the button labeled "Enable" in the row labeled "Clinical Data Pull from EHR"
 
 # ##VERIFY


### PR DESCRIPTION
@ellisthomas, these steps were causing intermittent cloud failures.  I could have fixed them by adding an "I should see" step to wait for the page to refresh before proceeding.  However, it looks like they might have been added accidentally to start with, and can likely be removed.  Do you agree?