### PR TITLE
ACG D-Items

### DIFF
--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.2200.- The system shall store ACG assignment in the user mapping table.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.2200.- The system shall store ACG assignment in the user mapping table.feature
@@ -1,0 +1,9 @@
+Feature: D.2.33.2200.: The system shall store user-to-ACG assignments in the user mapping table.---Database
+ As a Administrator I want to see that the system stores user-to-ACG assignments in the user mapping table.
+ 
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.

--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.2300.- The system shall store ACG definitions in ACG definitions table.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.2300.- The system shall store ACG definitions in ACG definitions table.feature
@@ -1,0 +1,10 @@
+Feature: D.2.33.2300.: The system shall store ACG definitions in the ACG definitions table.---Database
+
+ As a Administrator I want to see that the system stores ACG definitions in the ACG definitions table.
+ 
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.

--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.4900.- The system shall allow smart variables in violation message.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.4900.- The system shall allow smart variables in violation message.feature
@@ -1,0 +1,10 @@
+Feature: D.2.33.4900.: The system shall allow Smart Variables in the custom ACG violation message.---Control Center
+ 
+ As an administrator of REDCap I want to see that the system allows Smart Variables in the custom ACG violation message so that I can provide users with specific information about their compliance issues.
+
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.

--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.5100.- The system shall allow emailing users for ACG complaince.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.5100.- The system shall allow emailing users for ACG complaince.feature
@@ -1,0 +1,10 @@
+Feature: D.2.33.5100.: The system shall allow emailing users from the ACG Compliance page.---Project Compliance → Email
+
+ As a REDCap end user I want to see that the system allows emailing users from the ACG Compliance page so that I can easily communicate with users regarding compliance issues.
+
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.

--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.5200.- The system shall allow smart variables in ACG complaince email.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.5200.- The system shall allow smart variables in ACG complaince email.feature
@@ -1,0 +1,10 @@
+Feature: D.2.33.5200.: The system shall allow Smart Variables in ACG Compliance emails.---Project Compliance → Email Editor
+
+ As a REDCap end user I want to be able to use Smart Variables in ACG Compliance emails so that I can customize the content of the emails based on project-specific data.
+ 
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.

--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.5300.- The system shall evaluate ACG before project level validation.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.5300.- The system shall evaluate ACG before project level validation.feature
@@ -1,0 +1,10 @@
+Feature: D.2.33.5300.: The system shall evaluate ACG privileges before other project-level validation checks.---Project → User Rights
+
+ As a REDCap end user I want to see that ACG privileges are evaluated before other project-level validation checks so that users with ACG privileges can only have access to features governed by their ACG privileges, even if they have other project-level privileges that would normally allow access to those features.
+
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.

--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.5400.- The system shall support ACG smart variables.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.5400.- The system shall support ACG smart variables.feature
@@ -1,0 +1,10 @@
+Feature: D.2.33.5400.: The system shall support ACG-related Smart Variables.---Smart Variables List
+
+As a REDCap end user I want to see that the system supports ACG-related Smart Variables so that I can use these variables in my project to display information about ACG privileges and access.
+
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.

--- a/Feature Tests/D/AccessControlGroup_33/D.2.33.5500.- The system shall format smart variable output consistently.feature
+++ b/Feature Tests/D/AccessControlGroup_33/D.2.33.5500.- The system shall format smart variable output consistently.feature
@@ -1,0 +1,10 @@
+Feature: D.2.33.5500.: The system shall format Smart Variable output consistently and safely.---Smart Variables
+
+As a REDCap end user I want to see smart variable output formatted consistently and safely so that I can understand the information being presented and avoid potential security issues.
+
+For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
+Please include test guidance only, describing:
+• The user action or configuration to be exercised
+• The system behavior that should be observed
+• The expected outcome that would satisfy the requirement
+This guidance is intended to support local script development, not to serve as a validated test artifact.


### PR DESCRIPTION
This PR is intended to add files for the ACG D items. For D-level functional requirements, RVP does not provide and executed validation test. These items require site-authored testing if the functionality is in use.
