### PR TITLE
Update feature description for Open Survey Workflow

### DIFF
--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0500. - Survey Alerts and Prompts.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0500. - Survey Alerts and Prompts.feature
@@ -1,4 +1,4 @@
-Feature: User Interface: Survey Distribution: The system shall prohibit the user from overwriting partially or fully completed survey response from a data entry form when using Open Survey link.
+Feature: User Interface – Open Survey Workflow: The system shall warn users before saving a data entry form after the user launches the same record’s survey using the Open Survey option, allowing the user to leave without saving or remain on the form.
 
   As a REDCap end user
   I want to see that Survey Feature is functioning as expected


### PR DESCRIPTION
URS updated

User Interface – Open Survey Workflow: The system shall warn users before saving a data entry form after the user launches the same record’s survey using the Open Survey option, allowing the user to leave without saving or remain on the form.

Modified the URS to accurately reflect the observed system behavior of the Open Survey workflow. The previous requirement incorrectly stated that the system prohibits users from overwriting survey responses. In practice, REDCap presents a warning when a user returns to an open data entry form after launching a survey using the Open Survey option, allowing the user to either leave without saving or remain on the form and continue editing. The revised requirement reflects the warning-based workflow rather than an absolute prohibition on overwriting data.

