### PR TITLE
URS Update

### DIFF
--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0300. - Survey Distribution Participant List.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0300. - Survey Distribution Participant List.feature
@@ -1,4 +1,4 @@
-Feature: The system shall allow creation of a participant list automatically using a designated email field when a survey is in any instrument position.
+Feature: User Interface – Survey Settings: The system shall allow users to designate any email-validated text field within the project as the survey-specific email invitation field.
 
   As a REDCap end user
   I want to see that Participant List is functioning as expected


### PR DESCRIPTION
URS Update
User Interface – Survey Settings: The system shall allow users to designate any email-validated text field within the project as the survey-specific email invitation field.

Revised the URS to improve clarity and accurately reflect the implemented functionality. The original requirement ambiguously described automatic participant list creation and contained grammatical errors that obscured the feature's intent. The revised requirement clarifies that users designate an email-validated text field within the project as the survey-specific email invitation field, consistent with the REDCap Survey Settings functionality.

