### PR TITLE
Updates to tests as requested by the community.

### DIFF
--- a/Feature Tests/C/Randomization_30/C.3.30.1000. - Randomization assignment.feature
+++ b/Feature Tests/C/Randomization_30/C.3.30.1000. - Randomization assignment.feature
@@ -104,5 +104,17 @@ Feature: C.3.30.1000. User Interface: The system shall support the sequential as
         Then I should see 'Record ID "10" was randomized for the field "Automatic Randomization" and assigned the value "Group 2" (B).'
         And I click on the button labeled "Close"
         And I click on the button labeled "Save & Exit Form"
+
+        #Validation that the records were randomized correctly and that the logging table contains the expected values.
+        When I click on the link labeled "Logging"
+        Then I should see a table header and rows containing the following values in the logging table:
+        | Username   | Action                                   | List of Data Changes OR Fields Exported                                                              |
+        | test_user1 | Update record 10                         |                                                                                                      |
+        | test_user1 | Randomize Record 10                      | Randomize record                                                                                     |
+        | test_user1 | Create record 10                         | record_id = '10', auto_rand = 'B', gender = '0', randomization_complete = '0'                        |
+        | test_user1 | Update record 9                          |                                                                                                      |
+        | test_user1 | Randomize Record 9                       | Randomize record                                                                                     |
+        | test_user1 | Create record 9                          | record_id = '9', auto_rand = 'A', gender = '0', randomization_complete = '0'                        |
+
         And I logout
 #End

--- a/Files/import_files/AlloRand auto_randtextduplicate.csv
+++ b/Files/import_files/AlloRand auto_randtextduplicate.csv
@@ -1,21 +1,21 @@
-redcap_randomization_number,redcap_randomization_group,gender
-,A,0
-,B,0,,,"NOTES:"
-,C,0,,," - Do NOT modify the first row, although you may modify, add, or delete any other row in this file."
-,A,1,,," - Remember that this file is ONLY a template and should NOT be used as-is as your allocation table."
-,B,1,,," - You do not have to delete this 'notes' column when uploading your allocation table (it will be ignored)."
-,C,1,,," - Below is a list of all raw coded values and their corresponding option labels for each strata field and/or Data Access Groups."
-,A,2
-,B,2,,,"Randomization Field: ""auto_rand"" (Automatic Randomization)"
-,C,2,,,"Your randomization field is a single-select field (for open allocation):"
-,,,,," - Values in the redcap_randomization_number column are optional"
-,,,,," - Values in the redcap_randomization_group column are REQUIRED and must match the values for your randomization field"
-,,,,,"Values/labels for ""randomization_group"" (""auto_rand""):"
-,,,,,"A","Group 1"
-,,,,,"B","Group 2"
-,,,,,"C","Group 3"
-,,,,,""
-,,,,,"Values/labels for ""gender"" (Do you describe yourself as...other way?):"
-,,,,,"0","Man"
-,,,,,"1","Woman"
-,,,,,"2","Other"
+redcap_randomization_number,redcap_randomization_group,gender,,,,
+1,A,0,,,,
+1,B,0,,,NOTES:,
+,C,0,,," - Do NOT modify the first row, although you may modify, add, or delete any other row in this file.",
+,A,1,,, - Remember that this file is ONLY a template and should NOT be used as-is as your allocation table.,
+,B,1,,, - You do not have to delete this 'notes' column when uploading your allocation table (it will be ignored).,
+,C,1,,, - Below is a list of all raw coded values and their corresponding option labels for each strata field and/or Data Access Groups.,
+,A,2,,,,
+,B,2,,,"Randomization Field: ""auto_rand"" (Automatic Randomization)",
+,C,2,,,Your randomization field is a single-select field (for open allocation):,
+,,,,, - Values in the redcap_randomization_number column are optional,
+,,,,, - Values in the redcap_randomization_group column are REQUIRED and must match the values for your randomization field,
+,,,,,"Values/labels for ""randomization_group"" (""auto_rand""):",
+,,,,,A,Group 1
+,,,,,B,Group 2
+,,,,,C,Group 3
+,,,,,,
+,,,,,"Values/labels for ""gender"" (Do you describe yourself as...other way?):",
+,,,,,0,Man
+,,,,,1,Woman
+,,,,,2,Other


### PR DESCRIPTION
This PR includes a modification to C.3.30.1000. to account for Nathans community comment to update "AlloRand auto_randtextduplicate.csv" for the scenario C.3.30.1000.0200 "The system shall allow duplicate or non-numeric values in the redcap_randomization_number column" doesn't contain values in the redcap_randomization_number column. I also added a validation step when records get randomized. 